### PR TITLE
replace ProjectDescriptor with ProjectInterface

### DIFF
--- a/src/phpDocumentor/Compiler/CompilerPassInterface.php
+++ b/src/phpDocumentor/Compiler/CompilerPassInterface.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Compiler;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 
 /**
  * Represents a single pass / business rule to be executed by the Compiler.
@@ -32,11 +32,10 @@ interface CompilerPassInterface
      * Executes a compiler pass.
      *
      * This method will execute the business logic associated with a given compiler pass and allow it to manipulate
-     * or consumer the Object Graph using the ProjectDescriptor object.
+     * or consumer the Object Graph using the ProjectInterface object.
      *
-     * @param ProjectDescriptor $project Representation of the Object Graph that can be manipulated.
-     *
+     * @param ProjectInterface $project Representation of the Object Graph that can be manipulated.
      * @return mixed
      */
-    public function execute(ProjectDescriptor $project);
+    public function execute(ProjectInterface $project);
 }

--- a/src/phpDocumentor/Compiler/Linker/Linker.php
+++ b/src/phpDocumentor/Compiler/Linker/Linker.php
@@ -19,12 +19,11 @@ use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Descriptor\Type\UnknownTypeDescriptor;
 
 /**
- * The linker contains all rules to replace FQSENs in the ProjectDescriptor with aliases to objects.
+ * The linker contains all rules to replace FQSENs in the ProjectInterface with aliases to objects.
  *
  * This object contains a list of class FQCNs for Descriptors and their associated linker rules.
  *
@@ -75,11 +74,10 @@ class Linker implements CompilerPassInterface
     /**
      * Executes the linker.
      *
-     * @param ProjectDescriptor $project Representation of the Object Graph that can be manipulated.
+     * @param ProjectInterface $project Representation of the Object Graph that can be manipulated.
      *
-     * @return void
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         $this->setObjectAliasesList($project->getIndexes()->elements->getAll());
         $this->substitute($project);

--- a/src/phpDocumentor/Compiler/Pass/Debug.php
+++ b/src/phpDocumentor/Compiler/Pass/Debug.php
@@ -14,13 +14,13 @@ namespace phpDocumentor\Compiler\Pass;
 use Psr\Log\LoggerInterface;
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\ProjectAnalyzer;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 
 /**
  * This class is responsible for sending statistical information to the log.
  *
  * For debugging purposes it can be convenient to send statistical information about the
- * ProjectDescriptor to the log of phpDocumentor.
+ * ProjectInterface to the log of phpDocumentor.
  */
 class Debug implements CompilerPassInterface
 {
@@ -55,11 +55,10 @@ class Debug implements CompilerPassInterface
     /**
      * Analyzes the given project and returns the results to the logger.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
-     * @return void
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         $this->analyzer->analyze($project);
         $this->log->debug((string) $this->analyzer);

--- a/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
@@ -17,7 +17,7 @@ use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\Interfaces\ClassInterface;
 use phpDocumentor\Descriptor\Interfaces\InterfaceInterface;
 use phpDocumentor\Descriptor\Interfaces\TraitInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\Interfaces\PropertyInterface;
 
 /**
@@ -41,7 +41,7 @@ class ElementsIndexBuilder implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         $elementCollection = new Collection();
         $project->getIndexes()->set('elements', $elementCollection);

--- a/src/phpDocumentor/Compiler/Pass/ExampleTagsEnricher.php
+++ b/src/phpDocumentor/Compiler/Pass/ExampleTagsEnricher.php
@@ -14,7 +14,7 @@ namespace phpDocumentor\Compiler\Pass;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\Example\Finder;
 use phpDocumentor\Compiler\CompilerPassInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Reflection\DocBlock\Tag\ExampleTag;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\ExampleAssembler;
 
@@ -49,7 +49,7 @@ class ExampleTagsEnricher implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         $elements = $project->getIndexes()->get('elements');
 

--- a/src/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractor.php
+++ b/src/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractor.php
@@ -16,7 +16,7 @@ use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\TagDescriptor;
 use phpDocumentor\Compiler\CompilerPassInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 
 /**
  * This index builder collects all markers from tags and inserts them into the marker index.
@@ -36,7 +36,7 @@ class MarkerFromTagsExtractor implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         /** @var DescriptorAbstract $element */
         foreach ($project->getIndexes()->get('elements', new Collection()) as $element) {

--- a/src/phpDocumentor/Compiler/Pass/NamespaceTreeBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/NamespaceTreeBuilder.php
@@ -15,7 +15,7 @@ use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 
 /**
  * Rebuilds the namespace tree from the elements found in files.
@@ -42,7 +42,7 @@ class NamespaceTreeBuilder implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         $project->getIndexes()->get('elements', new Collection())->set('~\\', $project->getNamespace());
         $project->getIndexes()->get('namespaces', new Collection())->add($project->getNamespace());
@@ -62,7 +62,7 @@ class NamespaceTreeBuilder implements CompilerPassInterface
      * This method will assign the given elements to the namespace as registered in the namespace field of that
      * element. If a namespace does not exist yet it will automatically be created.
      *
-     * @param ProjectDescriptor    $project
+     * @param ProjectInterface     $project
      * @param DescriptorAbstract[] $elements Series of elements to add to their respective namespace.
      * @param string               $type     Declares which field of the namespace will be populated with the given
      * series of elements. This name will be transformed to a getter which must exist. Out of performance
@@ -70,7 +70,7 @@ class NamespaceTreeBuilder implements CompilerPassInterface
      *
      * @return void
      */
-    protected function addElementsOfTypeToNamespace(ProjectDescriptor $project, array $elements, $type)
+    protected function addElementsOfTypeToNamespace(ProjectInterface $project, array $elements, $type)
     {
         /** @var DescriptorAbstract $element */
         foreach ($elements as $element) {
@@ -105,19 +105,19 @@ class NamespaceTreeBuilder implements CompilerPassInterface
      * the FQNN if it doesn't exist in the namespaces field of the current namespace (starting with the root
      * Namespace in the Project Descriptor),
      *
-     * As an intended side effect this method also populates the *elements* index of the ProjectDescriptor with all
+     * As an intended side effect this method also populates the *elements* index of the ProjectInterface with all
      * created NamespaceDescriptors. Each index key is prefixed with a tilde (~) so that it will not conflict with
      * other FQSEN's, such as classes or interfaces.
      *
-     * @param ProjectDescriptor $project
-     * @param string            $namespaceName A FQNN of the namespace (and parents) to create.
+     * @param ProjectInterface $project
+     * @param string           $namespaceName A FQNN of the namespace (and parents) to create.
      *
-     * @see ProjectDescriptor::getNamespace() for the root namespace.
+     * @see ProjectInterface::getNamespace() for the root namespace.
      * @see NamespaceDescriptor::getNamespaces() for the child namespaces of a given namespace.
      *
      * @return void
      */
-    protected function createNamespaceDescriptorTree(ProjectDescriptor $project, $namespaceName)
+    protected function createNamespaceDescriptorTree(ProjectInterface $project, $namespaceName)
     {
         $parts   = explode('\\', ltrim($namespaceName, '\\'));
         $fqnn    = '';

--- a/src/phpDocumentor/Compiler/Pass/PackageTreeBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/PackageTreeBuilder.php
@@ -15,7 +15,7 @@ use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\PackageDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\TagDescriptor;
 
 /**
@@ -42,11 +42,10 @@ class PackageTreeBuilder implements CompilerPassInterface
     /**
      * Compiles a 'packages' index on the project and create all Package Descriptors necessary.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
-     * @return void
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         $rootPackageDescriptor = new PackageDescriptor();
         $rootPackageDescriptor->setName('\\');
@@ -69,7 +68,7 @@ class PackageTreeBuilder implements CompilerPassInterface
      * This method will assign the given elements to the package as registered in the package field of that
      * element. If a package does not exist yet it will automatically be created.
      *
-     * @param ProjectDescriptor    $project
+     * @param ProjectInterface    $project
      * @param DescriptorAbstract[] $elements Series of elements to add to their respective package.
      * @param string               $type     Declares which field of the package will be populated with the given
      * series of elements. This name will be transformed to a getter which must exist. Out of performance
@@ -77,7 +76,7 @@ class PackageTreeBuilder implements CompilerPassInterface
      *
      * @return void
      */
-    protected function addElementsOfTypeToPackage(ProjectDescriptor $project, array $elements, $type)
+    protected function addElementsOfTypeToPackage(ProjectInterface $project, array $elements, $type)
     {
         /** @var DescriptorAbstract $element */
         foreach ($elements as $element) {
@@ -126,19 +125,19 @@ class PackageTreeBuilder implements CompilerPassInterface
      * the FQNN if it doesn't exist in the packages field of the current package (starting with the root
      * Package in the Project Descriptor),
      *
-     * As an intended side effect this method also populates the *elements* index of the ProjectDescriptor with all
+     * As an intended side effect this method also populates the *elements* index of the ProjectInterface with all
      * created PackageDescriptors. Each index key is prefixed with a tilde (~) so that it will not conflict with
      * other FQSEN's, such as classes or interfaces.
      *
-     * @param ProjectDescriptor $project
-     * @param string            $packageName A FQNN of the package (and parents) to create.
+     * @param ProjectInterface $project
+     * @param string           $packageName A FQNN of the package (and parents) to create.
      *
-     * @see ProjectDescriptor::getPackage() for the root package.
+     * @see ProjectInterface::getPackage() for the root package.
      * @see PackageDescriptor::getChildren() for the child packages of a given package.
      *
      * @return void
      */
-    protected function createPackageDescriptorTree(ProjectDescriptor $project, $packageName)
+    protected function createPackageDescriptorTree(ProjectInterface $project, $packageName)
     {
         $parts   = explode('\\', ltrim($packageName, '\\'));
         $fqnn    = '';

--- a/src/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTags.php
+++ b/src/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTags.php
@@ -19,7 +19,7 @@ use phpDocumentor\Reflection\DocBlock\Type\Collection as TypeCollection;
 use phpDocumentor\Transformer\Router\Queue;
 use phpDocumentor\Transformer\Router\RouterAbstract;
 use phpDocumentor\Compiler\CompilerPassInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 
 /**
  * This step in the compilation process iterates through all elements and scans their descriptions for an inline `@see`
@@ -60,11 +60,10 @@ class ResolveInlineLinkAndSeeTags implements CompilerPassInterface
      * Iterates through each element in the project and replaces its inline @see and @link tag with a markdown
      * representation.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
-     * @return void
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         /** @var Collection|DescriptorAbstract[] $elementCollection */
         $this->elementCollection = $project->getIndexes()->get('elements');

--- a/src/phpDocumentor/Parser/Listeners/Cache.php
+++ b/src/phpDocumentor/Parser/Listeners/Cache.php
@@ -15,6 +15,7 @@ use Desarrolla2\Cache\Adapter\File;
 use Desarrolla2\Cache\CacheInterface;
 use phpDocumentor\Descriptor\Cache\ProjectDescriptorMapper;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Fileset\Collection;
 use phpDocumentor\Parser\Parser;
 use phpDocumentor\Translator\Translator;
@@ -116,11 +117,11 @@ class Cache
      * deleted entries and making sure no unwanted elements are loaded.
      *
      * @param Collection        $files
-     * @param ProjectDescriptor $projectDescriptor
+     * @param ProjectInterface $projectDescriptor
      *
      * @return void
      */
-    private function load(Collection $files, ProjectDescriptor $projectDescriptor)
+    private function load(Collection $files, ProjectInterface $projectDescriptor)
     {
         $this->mapper->populate($projectDescriptor);
 
@@ -149,11 +150,11 @@ class Cache
     /**
      * Stores the project descriptor in the cache.
      *
-     * @param ProjectDescriptor $projectDescriptor
+     * @param ProjectInterface $projectDescriptor
      *
      * @return void
      */
-    private function save(ProjectDescriptor $projectDescriptor)
+    private function save(ProjectInterface $projectDescriptor)
     {
         $this->mapper->save($projectDescriptor);
     }

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Checkstyle.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Checkstyle.php
@@ -12,7 +12,7 @@
 namespace phpDocumentor\Plugin\Core\Transformer\Writer;
 
 use phpDocumentor\Descriptor\FileDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\Validator\Error;
 use phpDocumentor\Transformer\Transformation;
 use phpDocumentor\Transformer\Writer\Translatable;
@@ -52,12 +52,12 @@ class Checkstyle extends WriterAbstract implements Translatable
     /**
      * This method generates the checkstyle.xml report
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
+     * @param ProjectInterface $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $artifact = $this->getDestinationPath($transformation);
 

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/FileIo.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/FileIo.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Plugin\Core\Transformer\Writer;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Transformer\Exception;
 use phpDocumentor\Transformer\Transformation;
 use phpDocumentor\Transformer\Writer\WriterAbstract;
@@ -35,14 +35,14 @@ class FileIo extends WriterAbstract
     /**
      * Invokes the query method contained in this class.
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
+     * @param ProjectInterface $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @throws \InvalidArgumentException if the query is not supported.
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $artifact = $transformation->getTransformer()->getTarget()
             . DIRECTORY_SEPARATOR . $transformation->getArtifact();

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Jsonp.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Jsonp.php
@@ -12,7 +12,7 @@ use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\MethodDescriptor;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
 use phpDocumentor\Descriptor\PackageDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\PropertyDescriptor;
 use phpDocumentor\Descriptor\TagDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
@@ -66,12 +66,12 @@ final class Jsonp extends WriterAbstract
      * user when starting phpDocumentor. A complete description of what is generated can be found in the documentation
      * of this class itself.
      *
-     * @param ProjectDescriptor $project Document containing the structure.
+     * @param ProjectInterface $project Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $folder = $transformation->getTransformer()->getTarget() . DIRECTORY_SEPARATOR . $transformation->getArtifact();
         @mkdir($folder . 'classes');

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Sourcecode.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Sourcecode.php
@@ -12,7 +12,7 @@
 namespace phpDocumentor\Plugin\Core\Transformer\Writer;
 
 use phpDocumentor\Descriptor\FileDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Transformer\Transformation;
 use phpDocumentor\Transformer\Writer\WriterAbstract;
 
@@ -24,12 +24,12 @@ class Sourcecode extends WriterAbstract
     /**
      * This method writes every source code entry in the structure file to a highlighted file.
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
+     * @param ProjectInterface  $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $artifact = $transformation->getTransformer()->getTarget()
             . DIRECTORY_SEPARATOR

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Statistics.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Statistics.php
@@ -13,7 +13,7 @@ namespace phpDocumentor\Plugin\Core\Transformer\Writer;
 
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\FileDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Transformer\Transformation;
 use phpDocumentor\Application;
 
@@ -41,12 +41,12 @@ class Statistics extends Checkstyle
     /**
      * This method generates the checkstyle.xml report
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
+     * @param ProjectInterface $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $artifact = $this->getDestinationPath($transformation);
 
@@ -88,12 +88,12 @@ class Statistics extends Checkstyle
      * Appends a stat fragment.
      *
      * @param \DOMDocument $document
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      * @param string $date
      *
      * @return \DOMDocument
      */
-    protected function appendStatElement(\DOMDocument $document, ProjectDescriptor $project, $date)
+    protected function appendStatElement(\DOMDocument $document, ProjectInterface $project, $date)
     {
         $stat = $document->createDocumentFragment();
         $stat->appendXML(
@@ -116,11 +116,11 @@ STAT
     /**
      * Get number of files.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
      * @return int
      */
-    protected function getFilesCounter(ProjectDescriptor $project)
+    protected function getFilesCounter(ProjectInterface $project)
     {
         return $project->getFiles()->count();
     }
@@ -128,11 +128,11 @@ STAT
     /**
      * Get number of deprecated elements.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
      * @return int
      */
-    protected function getDeprecatedCounter(ProjectDescriptor $project)
+    protected function getDeprecatedCounter(ProjectInterface $project)
     {
         $deprecatedCounter = 0;
 
@@ -149,11 +149,11 @@ STAT
     /**
      * Get number of errors.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
      * @return int
      */
-    protected function getErrorCounter(ProjectDescriptor $project)
+    protected function getErrorCounter(ProjectInterface $project)
     {
         $errorCounter = 0;
 
@@ -168,11 +168,11 @@ STAT
     /**
      * Get number of markers.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
      * @return int
      */
-    protected function getMarkerCounter(ProjectDescriptor $project)
+    protected function getMarkerCounter(ProjectInterface $project)
     {
         $markerCounter = 0;
 

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml.php
@@ -30,6 +30,7 @@ use phpDocumentor\Descriptor\ConstantDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\FunctionDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Plugin\Core\Transformer\Behaviour\Tag\AuthorTag;
@@ -116,12 +117,12 @@ class Xml extends WriterAbstract implements Translatable
     /**
      * This method generates the AST output
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
+     * @param ProjectInterface $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $artifact = $this->getDestinationPath($transformation);
 
@@ -147,7 +148,7 @@ class Xml extends WriterAbstract implements Translatable
         file_put_contents($artifact, $this->xml->saveXML());
     }
 
-    protected function buildPartials(\DOMElement $parent, ProjectDescriptor $project)
+    protected function buildPartials(\DOMElement $parent, ProjectInterface $project)
     {
         $child = new \DOMElement('partials');
         $parent->appendChild($child);
@@ -427,11 +428,11 @@ class Xml extends WriterAbstract implements Translatable
      * - Deprecated elements listing
      * - Removal of objects related to visibility
      *
-     * @param ProjectDescriptor $projectDescriptor
+     * @param ProjectInterface $projectDescriptor
      *
      * @return void
      */
-    protected function finalize(ProjectDescriptor $projectDescriptor)
+    protected function finalize(ProjectInterface $projectDescriptor)
     {
         // TODO: move all these behaviours to a central location for all template parsers
         $behaviour = new AuthorTag();

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xsl.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xsl.php
@@ -13,7 +13,7 @@ namespace phpDocumentor\Plugin\Core\Transformer\Writer;
 
 use Monolog\Logger;
 use phpDocumentor\Application;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Event\Dispatcher;
 use phpDocumentor\Plugin\Core\Exception;
 use phpDocumentor\Transformer\Event\PreXslWriterEvent;
@@ -84,7 +84,7 @@ class Xsl extends WriterAbstract implements Routable
      * This method combines the structure.xml and the given target template
      * and creates a static html page at the artifact location.
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
+     * @param ProjectInterface  $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @throws \RuntimeException if the structure.xml file could not be found.
@@ -93,7 +93,7 @@ class Xsl extends WriterAbstract implements Routable
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $structure = $this->loadAst($this->getAstPath($transformation));
 
@@ -332,11 +332,11 @@ class Xsl extends WriterAbstract implements Routable
     }
 
     /**
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      * @param $element
      * @return false|string
      */
-    private function generateUrlForXmlElement(ProjectDescriptor $project, $element)
+    private function generateUrlForXmlElement(ProjectInterface $project, $element)
     {
         $elements = $project->getIndexes()->get('elements');
 

--- a/src/phpDocumentor/Plugin/Graphs/Writer/Graph.php
+++ b/src/phpDocumentor/Plugin/Graphs/Writer/Graph.php
@@ -15,7 +15,7 @@ use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\GraphViz\Edge;
 use phpDocumentor\GraphViz\Graph as GraphVizGraph;
@@ -46,12 +46,12 @@ class Graph extends WriterAbstract
     /**
      * Invokes the query method contained in this class.
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
+     * @param ProjectInterface  $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $type_method = 'process' . ucfirst($transformation->getSource());
         $this->$type_method($project, $transformation);
@@ -60,12 +60,12 @@ class Graph extends WriterAbstract
     /**
      * Creates a class inheritance diagram.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface  $project
      * @param Transformation    $transformation
      *
      * @return void
      */
-    public function processClass(ProjectDescriptor $project, Transformation $transformation)
+    public function processClass(ProjectInterface $project, Transformation $transformation)
     {
         try {
             $this->checkIfGraphVizIsInstalled();

--- a/src/phpDocumentor/Plugin/Twig/Extension.php
+++ b/src/phpDocumentor/Plugin/Twig/Extension.php
@@ -12,7 +12,7 @@
 namespace phpDocumentor\Plugin\Twig;
 
 use phpDocumentor\Descriptor\Collection;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Transformer\Router\Queue;
 use phpDocumentor\Transformer\Router\Renderer;
 use phpDocumentor\Transformer\Transformation;
@@ -42,7 +42,7 @@ use phpDocumentor\Translator\Translator;
 class Extension extends \Twig_Extension implements ExtensionInterface
 {
     /**
-     * @var ProjectDescriptor
+     * @var ProjectInterface
      */
     protected $data = null;
 
@@ -55,11 +55,11 @@ class Extension extends \Twig_Extension implements ExtensionInterface
     /**
      * Registers the structure and transformation with this extension.
      *
-     * @param ProjectDescriptor $project        Represents the complete Abstract Syntax Tree.
+     * @param ProjectInterface $project        Represents the complete Abstract Syntax Tree.
      * @param Transformation    $transformation Represents the transformation meta data used in the current generation
      *     cycle.
      */
-    public function __construct(ProjectDescriptor $project, Transformation $transformation)
+    public function __construct(ProjectInterface $project, Transformation $transformation)
     {
         $this->data          = $project;
         $this->routeRenderer = new Renderer(new Queue());

--- a/src/phpDocumentor/Plugin/Twig/ExtensionInterface.php
+++ b/src/phpDocumentor/Plugin/Twig/ExtensionInterface.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Plugin\Twig;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces;
 use phpDocumentor\Transformer\Transformation;
 
 /**
@@ -25,9 +25,9 @@ interface ExtensionInterface
      * The Structure and Transformation object can be used to get context from
      * and to provide additional information.
      *
-     * @param ProjectDescriptor $project        Represents the complete Abstract Syntax Tree.
+     * @param ProjectInterface  $project        Represents the complete Abstract Syntax Tree.
      * @param Transformation    $transformation Represents the transformation meta data used in the current generation
      *     cycle.
      */
-    public function __construct(ProjectDescriptor $project, Transformation $transformation);
+    public function __construct(ProjectInterface $project, Transformation $transformation);
 }

--- a/src/phpDocumentor/Plugin/Twig/Writer/Twig.php
+++ b/src/phpDocumentor/Plugin/Twig/Writer/Twig.php
@@ -12,7 +12,7 @@
 namespace phpDocumentor\Plugin\Twig\Writer;
 
 use phpDocumentor\Descriptor\DescriptorAbstract;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Plugin\Core\Transformer\Writer\Pathfinder;
 use phpDocumentor\Plugin\Twig\Extension;
 use phpDocumentor\Transformer\Router\ForFileProxy;
@@ -90,12 +90,12 @@ class Twig extends WriterAbstract implements Routable
      * This method combines the ProjectDescriptor and the given target template
      * and creates a static html page at the artifact location.
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
-     * @param Transformation    $transformation Transformation to execute.
+     * @param ProjectInterface $project        Document containing the structure.
+     * @param Transformation   $transformation Transformation to execute.
      *
      * @return void
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation)
+    public function transform(ProjectInterface $project, Transformation $transformation)
     {
         $template_path = $this->getTemplatePath($transformation);
 
@@ -121,13 +121,13 @@ class Twig extends WriterAbstract implements Routable
     /**
      * Initializes the Twig environment with the template, base extension and additionally defined extensions.
      *
-     * @param ProjectDescriptor $project
-     * @param Transformation    $transformation
-     * @param string            $destination
+     * @param ProjectInterface $project
+     * @param Transformation   $transformation
+     * @param string           $destination
      *
      * @return \Twig_Environment
      */
-    protected function initializeEnvironment(ProjectDescriptor $project, Transformation $transformation, $destination)
+    protected function initializeEnvironment(ProjectInterface $project, Transformation $transformation, $destination)
     {
         $callingTemplatePath = $this->getTemplatePath($transformation);
 
@@ -160,7 +160,7 @@ class Twig extends WriterAbstract implements Routable
     /**
      * Adds the phpDocumentor base extension to the Twig Environment.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface  $project
      * @param Transformation    $transformation
      * @param string            $destination
      * @param \Twig_Environment $twigEnvironment
@@ -168,7 +168,7 @@ class Twig extends WriterAbstract implements Routable
      * @return void
      */
     protected function addPhpDocumentorExtension(
-        ProjectDescriptor $project,
+        ProjectInterface $project,
         Transformation $transformation,
         $destination,
         \Twig_Environment $twigEnvironment
@@ -189,7 +189,7 @@ class Twig extends WriterAbstract implements Routable
      * parameter set) and try to add those extensions to the environment.
      *
      * @param Transformation    $transformation
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface  $project
      * @param \Twig_Environment $twigEnvironment
      *
      * @throws \InvalidArgumentException if a twig-extension should be loaded but it could not be found.
@@ -198,7 +198,7 @@ class Twig extends WriterAbstract implements Routable
      */
     protected function addExtensionsFromTemplateConfiguration(
         Transformation $transformation,
-        ProjectDescriptor $project,
+        ProjectInterface $project,
         \Twig_Environment $twigEnvironment
     ) {
         $isDebug = $transformation->getParameter('twig-debug')

--- a/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
@@ -11,7 +11,6 @@
 
 namespace phpDocumentor\Transformer\Event;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Event\EventAbstract;
 
 /**

--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -16,7 +16,7 @@ use phpDocumentor\Transformer\Writer\Initializable;
 use phpDocumentor\Transformer\Writer\WriterAbstract;
 use Psr\Log\LogLevel;
 use phpDocumentor\Compiler\CompilerPassInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Event\DebugEvent;
 use phpDocumentor\Event\Dispatcher;
 use phpDocumentor\Event\LogEvent;
@@ -125,11 +125,10 @@ class Transformer implements CompilerPassInterface
     /**
      * Transforms the given project into a series of artifacts as provided by the templates.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
-     * @return void
      */
-    public function execute(ProjectDescriptor $project)
+    public function execute(ProjectInterface $project)
     {
         Dispatcher::getInstance()->dispatch(
             self::EVENT_PRE_TRANSFORM,
@@ -206,12 +205,12 @@ class Transformer implements CompilerPassInterface
     /**
      * Initializes all writers that are used during this transformation.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      * @param Transformation[]  $transformations
      *
      * @return void
      */
-    private function initializeWriters(ProjectDescriptor $project, $transformations)
+    private function initializeWriters(ProjectInterface $project, $transformations)
     {
         $isInitialized = array();
         foreach ($transformations as $transformation) {
@@ -242,13 +241,13 @@ class Transformer implements CompilerPassInterface
      * - transformer.writer.initialization.post, after the initialization of a single writer.
      *
      * @param WriterAbstract    $writer
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
      * @uses Dispatcher to emit the events surrounding an initialization.
      *
      * @return void
      */
-    private function initializeWriter(WriterAbstract $writer, ProjectDescriptor $project)
+    private function initializeWriter(WriterAbstract $writer, ProjectInterface $project)
     {
         $event = WriterInitializationEvent::createInstance($this)->setWriter($writer);
         Dispatcher::getInstance()->dispatch(self::EVENT_PRE_INITIALIZATION, $event);
@@ -263,12 +262,12 @@ class Transformer implements CompilerPassInterface
     /**
      * Applies all given transformations to the provided project.
      *
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      * @param Transformation[]  $transformations
      *
      * @return void
      */
-    private function transformProject(ProjectDescriptor $project, $transformations)
+    private function transformProject(ProjectInterface $project, $transformations)
     {
         foreach ($transformations as $transformation) {
             $transformation->setTransformer($this);
@@ -288,13 +287,13 @@ class Transformer implements CompilerPassInterface
      * - transformer.transformation.post, after the project has been transformed with this transformation
      *
      * @param Transformation $transformation
-     * @param ProjectDescriptor $project
+     * @param ProjectInterface $project
      *
      * @uses Dispatcher to emit the events surrounding a transformation.
      *
      * @return void
      */
-    private function applyTransformationToProject(Transformation $transformation, ProjectDescriptor $project)
+    private function applyTransformationToProject(Transformation $transformation, ProjectInterface $project)
     {
         $this->log(
             sprintf(

--- a/src/phpDocumentor/Transformer/Writer/Initializable.php
+++ b/src/phpDocumentor/Transformer/Writer/Initializable.php
@@ -2,9 +2,9 @@
 
 namespace phpDocumentor\Transformer\Writer;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 
 interface Initializable
 {
-    public function initialize(ProjectDescriptor $projectDescriptor);
+    public function initialize(ProjectInterface $projectDescriptor);
 }

--- a/src/phpDocumentor/Transformer/Writer/WriterAbstract.php
+++ b/src/phpDocumentor/Transformer/Writer/WriterAbstract.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Writer;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Transformer\Transformation;
 
 /**
@@ -53,10 +53,10 @@ abstract class WriterAbstract
     /**
      * Abstract definition of the transformation method.
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
+     * @param ProjectInterface  $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
      *
      * @return void
      */
-    abstract public function transform(ProjectDescriptor $project, Transformation $transformation);
+    abstract public function transform(ProjectInterface $project, Transformation $transformation);
 }

--- a/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
@@ -288,7 +288,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
         $std->shouldReceive('getAll')->andReturn(array());
         $indexes = new \stdClass();
         $indexes->elements = $std;
-        $descriptor = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $descriptor = m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface');
         $descriptor->shouldReceive('getIndexes')->andReturn($indexes);
 
         $mock = m::mock('phpDocumentor\Compiler\Linker\Linker');

--- a/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
@@ -39,7 +39,7 @@ class DebugTest extends \PHPUnit_Framework_TestCase
     public function testLogDebugAnalysis()
     {
         $testString            = 'test';
-        $projectDescriptorMock = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $projectDescriptorMock = m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface');
 
         $loggerMock = m::mock('Psr\Log\LoggerInterface')
             ->shouldReceive('debug')->with($testString)

--- a/tests/unit/phpDocumentor/Compiler/Pass/ExampleTagsEnricherTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ExampleTagsEnricherTest.php
@@ -141,7 +141,7 @@ class ExampleTagsEnricherTest extends \PHPUnit_Framework_TestCase
      */
     private function givenAProjectDescriptorWithChildDescriptors($descriptors)
     {
-        $projectDescriptor = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $projectDescriptor = m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface');
         $projectDescriptor->shouldReceive('getIndexes->get')->with('elements')->andReturn($descriptors);
 
         return $projectDescriptor;

--- a/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/CheckStyleTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/CheckStyleTest.php
@@ -54,7 +54,7 @@ class CheckStyleTest extends \PHPUnit_Framework_TestCase
         $transformer->shouldReceive('getArtifact')->andReturn('artifact.xml');
 
         $fileDescriptor = m::mock('phpDocumentor\Descriptor\FileDescriptor');
-        $projectDescriptor = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $projectDescriptor = m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface');
         $projectDescriptor->shouldReceive('getFiles->getAll')->andReturn(array($fileDescriptor));
 
         $error = m::mock('phpDocumentor\Descriptor\Validator\Error');

--- a/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/StatisticsTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/StatisticsTest.php
@@ -86,7 +86,7 @@ class StatisticsTest extends \PHPUnit_Framework_TestCase
      */
     private function givenAProjectDescriptor($fileDescriptor)
     {
-        $projectDescriptor = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $projectDescriptor = m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface');
         $projectDescriptor->shouldReceive('getFiles->getAll')->andReturn(array($fileDescriptor));
         $projectDescriptor->shouldReceive('getFiles->count')->andReturn(1);
         $projectDescriptor->shouldReceive('getIndexes->get')->andReturn(array($fileDescriptor));

--- a/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/XmlTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/XmlTest.php
@@ -13,6 +13,7 @@
 namespace phpDocumentor\Plugin\Core\Transformer\Writer;
 
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 
 use Mockery as m;
@@ -36,7 +37,7 @@ class XmlTest extends \PHPUnit_Framework_TestCase
     /** @var m\MockInterface|Translator */
     protected $translator;
 
-    /** @var m\MockInterface|ProjectDescriptor */
+    /** @var m\MockInterface|ProjectInterface */
     protected $projectDescriptor;
 
     /** @var vfsStream */
@@ -51,7 +52,7 @@ class XmlTest extends \PHPUnit_Framework_TestCase
     {
         $this->fs                = vfsStream::setup('XmlTest');
         $this->translator        = m::mock('phpDocumentor\Translator\Translator');
-        $this->projectDescriptor = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $this->projectDescriptor = m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface');
         $this->routerMock        = m::mock('phpDocumentor\Transformer\Router\RouterAbstract');
         $this->xml               = new Xml($this->routerMock);
         $this->xml->setTranslator($this->translator);
@@ -171,10 +172,10 @@ XML;
     /**
      * This implements testing of the protected finalize method.
      *
-     * @param ProjectDescriptor $projectDescriptor
+     * @param ProjectInterface $projectDescriptor
      * @return void
      */
-    protected function implementProtectedFinalize(ProjectDescriptor $projectDescriptor)
+    protected function implementProtectedFinalize(ProjectInterface $projectDescriptor)
     {
         $this->projectDescriptor->shouldReceive('isVisibilityAllowed')
             ->with(ProjectDescriptor\Settings::VISIBILITY_INTERNAL)

--- a/tests/unit/phpDocumentor/Transformer/Event/PreTransformEventTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Event/PreTransformEventTest.php
@@ -36,7 +36,7 @@ class PreTransformEventTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetAndGetProject()
     {
-        $project = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $project = m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface');
         $this->assertSame(null, $this->fixture->getProject());
 
         $this->fixture->setProject($project);

--- a/tests/unit/phpDocumentor/Transformer/TransformerTest.php
+++ b/tests/unit/phpDocumentor/Transformer/TransformerTest.php
@@ -117,7 +117,7 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
 
         $templateCollection = m::mock('phpDocumentor\Transformer\Template\Collection');
 
-        $project = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $project = m::mock('phpDocumentor\Descriptor\Interfaces\ProjectInterface');
 
         $myTestWritterMock = m::mock('phpDocumentor\Transformer\Writer\WriterAbstract')
             ->shouldReceive('transform')->getMock();


### PR DESCRIPTION
ProjectDescriptor is final it can be mocked so replace it with ProjectInterface. This is causing a number of test failures in PhpDocumentor2.

Warning: this is a BC break!
This PR depends on https://github.com/phpDocumentor/Reflection/pull/36