### PR TITLE
Fixed @see tag links for classes #1620

### DIFF
--- a/data/templates/clean/class.html.twig
+++ b/data/templates/clean/class.html.twig
@@ -228,7 +228,7 @@
                         <dt>See also</dt>
                             {% endif %}
                             {% for tag in tags %}
-                            <dd><a href="{{ tag.link }}"><div class="namespace-wrapper">{{ tag.description }}</div></a></dd>
+                                <dd><a href="{{ (tag.reference|route('url')) ?: tag.link }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
                             {% endfor %}
                         {% endfor %}
 

--- a/data/templates/clean/elements/method.html.twig
+++ b/data/templates/clean/elements/method.html.twig
@@ -86,7 +86,7 @@
                         <dt>See also</dt>
                     {% endif %}
                     {% for tag in tags %}
-                        <dd><a href="{{ (tag.reference|route('url')) ?: tag.link }}"><span class="namespace-wrapper">{{ tag.description }}</span></a></dd>
+                        <dd><a href="{{ (tag.reference|route('url')) ?: tag.link }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
                     {% endfor %}
                 {% endfor %}
                 {% for tagName,tags in method.tags if tagName in ['uses'] %}


### PR DESCRIPTION
A fix for issue #1620. @see links in class docblocks now link correctly.

You no longer have to specify link text for @see tags in class or
method blocks.