### PR TITLE
Loosen dependency on JMS/SerializerBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 
         "twig/twig":         "^1.3",
         "erusev/parsedown":  "^1.0",
-        "jms/serializer":    "~0.12",
+        "jms/serializer":    ">=0.12",
         "desarrolla2/cache": "^1.8",
 
         "symfony/event-dispatcher": "^2.1",


### PR DESCRIPTION
Currently JMS/SerializerBundle's `v1.0.0` release is not supported. This PR fixes that.

Please create another release (tag) when (if) you merge this PR.