### PR TITLE
Fixing getLatestVersion line feed

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -811,6 +811,8 @@ XML
      */
     private function getLatestVersion()
     {
-        return file_get_contents('https://raw.githubusercontent.com/phpDocumentor/phpDocumentor2/master/VERSION');
+        $version = file_get_contents('https://raw.githubusercontent.com/phpDocumentor/phpDocumentor2/master/VERSION');
+        $version = str_replace("\n", '', $version);
+        return $version;
     }
 }


### PR DESCRIPTION
Fixing the version line feed for the feature "when I download the latest phar from github to phpDocumentor.phar"