### PR TITLE
Fix for #1677 : correct validation tests on `@param` tags

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Functions/DoesParamsExistsValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Functions/DoesParamsExistsValidator.php
@@ -36,7 +36,7 @@ class DoesParamsExistsValidator extends ConstraintValidator
         $arguments  = $value->arguments;
         $parameters = $value->parameters;
 
-        if (count($arguments) > 0 && is_array($parameters)) {
+        if (count($arguments) > 0 && $parameters instanceof \ArrayAccess) {
             foreach ($parameters as $param) {
                 $paramVarName = $param->getVariableName();
 

--- a/src/phpDocumentor/Plugin/Core/Descriptor/Validator/ValidationValueObject.php
+++ b/src/phpDocumentor/Plugin/Core/Descriptor/Validator/ValidationValueObject.php
@@ -44,4 +44,9 @@ class ValidationValueObject extends \ArrayObject
             $this->data[$name] = $value;
         }
     }
+
+    public function __isset($name)
+    {
+        return array_key_exists($name, $this->data);
+    }
 }


### PR DESCRIPTION
As seen in #1677, some errors and notices wasn't found for the `@param` tag in dockblock. 