### PR TITLE
#1589: Replace deprecated Symfony2 classes with the new counterparts

### DIFF
--- a/src/phpDocumentor/ContainerDefinitions.php
+++ b/src/phpDocumentor/ContainerDefinitions.php
@@ -45,12 +45,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
-use Symfony\Component\Validator\DefaultTranslator;
+use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
-use Symfony\Component\Validator\MetadataFactoryInterface;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
-use Symfony\Component\Validator\Validator;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\RecursiveValidator;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 // maintain BC in XSL-based templates
 if (!class_exists('phpDocumentor\\Plugin\\Core\\Xslt\\Extension')) {
@@ -135,11 +134,11 @@ return [
     },
 
     // Validator
-    ValidatorInterface::class => \DI\object(Validator::class),
-    MetadataFactoryInterface::class => \DI\object(LazyLoadingMetadataFactory::class)
+    ValidatorInterface::class => \DI\object(RecursiveValidator::class),
+    LazyLoadingMetadataFactory::class => \DI\object(LazyLoadingMetadataFactory::class)
         ->constructorParameter('loader', \DI\object(StaticMethodLoader::class)),
     ConstraintValidatorFactoryInterface::class => \DI\object(ConstraintValidatorFactory::class),
-    TranslatorInterface::class => \DI\object(DefaultTranslator::class),
+    TranslatorInterface::class => \DI\object(IdentityTranslator::class),
 
     //Definition Factories
     DocumentGroupDefinitionFactory::class => \DI\object(DocumentGroupDefinitionFactory::class),

--- a/src/phpDocumentor/Plugin/Core/Descriptor/Validator/DefaultValidators.php
+++ b/src/phpDocumentor/Plugin/Core/Descriptor/Validator/DefaultValidators.php
@@ -14,7 +14,7 @@ namespace phpDocumentor\Plugin\Core\Descriptor\Validator;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints as phpDocAssert;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class DefaultValidators
 {


### PR DESCRIPTION
These changes should fix the deprecated messages for Symfony components.