### PR TITLE
Adds command to reconfigure cache pool.

### DIFF
--- a/src/phpDocumentor/Application/Cli/Command/RunCommand.php
+++ b/src/phpDocumentor/Application/Cli/Command/RunCommand.php
@@ -17,6 +17,7 @@ use League\Tactician\CommandBus;
 use phpDocumentor\ApiReference\DocumentGroupDefinition;
 use phpDocumentor\ApiReference\FileParsed;
 use phpDocumentor\ApiReference\ParsingStarted;
+use phpDocumentor\Application\Commands\ConfigureCache;
 use phpDocumentor\Application\Commands\MergeConfigurationWithCommandLineOptions;
 use phpDocumentor\Application\Commands\Render;
 use phpDocumentor\DocumentationFactory;
@@ -276,6 +277,10 @@ HELP
 
         $this->commandBus->handle(
             new MergeConfigurationWithCommandLineOptions($input->getOptions(), $input->getArguments())
+        );
+
+        $this->commandBus->handle(
+            new ConfigureCache()
         );
 
         foreach ($this->definitionRepository->fetchAll() as $definition) {

--- a/src/phpDocumentor/Application/Commands/ConfigureCache.php
+++ b/src/phpDocumentor/Application/Commands/ConfigureCache.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Application\Commands;
+
+final class ConfigureCache
+{
+
+}

--- a/src/phpDocumentor/Application/Commands/ConfigureCacheHandler.php
+++ b/src/phpDocumentor/Application/Commands/ConfigureCacheHandler.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Application\Commands;
+
+use phpDocumentor\Application\Configuration\ConfigurationFactory;
+use Stash\Pool;
+
+final class ConfigureCacheHandler
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var ConfigurationFactory
+     */
+    private $configurationFactory;
+
+    /**
+     * ConfigureCacheHandler constructor.
+     */
+    public function __construct(Pool $pool, ConfigurationFactory $configurationFactory)
+    {
+
+        $this->pool = $pool;
+        $this->configurationFactory = $configurationFactory;
+    }
+
+    public function __invoke()
+    {
+        $this->pool->getDriver()->setOptions(
+            [
+                'path' => $this->configurationFactory->get()['phpdocumentor']['paths']['cache']
+            ]
+        );
+
+        if ($this->configurationFactory->get()['phpdocumentor']['use-cache'] === false) {
+            $this->pool->flush();
+        }
+    }
+}

--- a/src/phpDocumentor/Application/Configuration/Factory/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Application/Configuration/Factory/CommandlineOptionsMiddleware.php
@@ -32,6 +32,7 @@ final class CommandlineOptionsMiddleware
     public function __invoke(array $configuration)
     {
         $configuration = $this->overwriteDestinationFolder($configuration);
+        $configuration = $this->disableCache($configuration);
         $configuration = $this->overwriteCacheFolder($configuration);
         $configuration = $this->overwriteTitle($configuration);
         $configuration = $this->overwriteTemplates($configuration);
@@ -282,6 +283,15 @@ final class CommandlineOptionsMiddleware
     {
         if ($this->options['template']) {
             $configuration['templates'] = (string)$this->options['template'];
+        }
+
+        return $configuration;
+    }
+
+    private function disableCache($configuration)
+    {
+        if ($this->options['force']) {
+            $configuration['phpdocumentor']['use-cache'] = false;
         }
 
         return $configuration;

--- a/src/phpDocumentor/Application/Configuration/Factory/PhpDocumentor2.php
+++ b/src/phpDocumentor/Application/Configuration/Factory/PhpDocumentor2.php
@@ -41,6 +41,7 @@ final class PhpDocumentor2 implements Strategy
 
         $phpdoc2Array = [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'     => [
                     'output' => (new Dsn($outputDirectory))->getPath(),
                     'cache'  => '/tmp/phpdoc-doc-cache',

--- a/src/phpDocumentor/Application/Configuration/Factory/PhpDocumentor3.php
+++ b/src/phpDocumentor/Application/Configuration/Factory/PhpDocumentor3.php
@@ -59,6 +59,7 @@ final class PhpDocumentor3 implements Strategy
 
         $phpdoc3Array = [
             'phpdocumentor' => [
+                'use-cache' => $phpDocumentor->{"use-cache"} ?: true,
                 'paths'     => [
                     'output' => ((string) $phpDocumentor->paths->output) ?: 'file://build/docs',
                     'cache'  => ((string) $phpDocumentor->paths->cache) ?: '/tmp/phpdoc-doc-cache',

--- a/src/phpDocumentor/ContainerDefinitions.php
+++ b/src/phpDocumentor/ContainerDefinitions.php
@@ -208,7 +208,7 @@ return [
 
     // Infrastructure
     Pool::class => function (ContainerInterface $c) {
-        $adapter = new \Stash\Driver\BlackHole();
+        $adapter = new \Stash\Driver\FileSystem();
         $adapter->setOptions(['path' => $c->get('cache.directory')]);
         return new Pool($adapter);
     },

--- a/tests/data/phpDocumentor2ExpectedArray.php
+++ b/tests/data/phpDocumentor2ExpectedArray.php
@@ -24,6 +24,7 @@ final class PhpDocumentor2ExpectedArray
     {
         return [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'     => [
                     'output' => 'build/docs',
                     'cache'  => '/tmp/phpdoc-doc-cache',
@@ -76,6 +77,7 @@ final class PhpDocumentor2ExpectedArray
     {
         return [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'    => [
                     'output' => 'build/docs',
                     'cache'  => '/tmp/phpdoc-doc-cache',

--- a/tests/data/phpDocumentor3ExpectedArrays.php
+++ b/tests/data/phpDocumentor3ExpectedArrays.php
@@ -24,6 +24,7 @@ final class PhpDocumentor3ExpectedArrays
     {
         return [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'     => [
                     'output' => 'file://build/docs',
                     'cache'  => '/tmp/phpdoc-doc-cache'
@@ -90,6 +91,7 @@ final class PhpDocumentor3ExpectedArrays
     {
         return [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'     => [
                     'output' => 'file://build/docs',
                     'cache'  => '/tmp/phpdoc-doc-cache'
@@ -136,6 +138,7 @@ final class PhpDocumentor3ExpectedArrays
     {
         return [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'     => [
                     'output' => 'file://build/docs',
                     'cache'  => '/tmp/phpdoc-doc-cache'
@@ -161,6 +164,7 @@ final class PhpDocumentor3ExpectedArrays
     {
         return [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'     => [
                     'output' => 'file://build/docs',
                     'cache'  => '/tmp/phpdoc-doc-cache'
@@ -237,6 +241,7 @@ final class PhpDocumentor3ExpectedArrays
     {
         return [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'     => [
                     'output' => 'file://build/docs',
                     'cache'  => '/tmp/phpdoc-doc-cache'
@@ -279,6 +284,7 @@ final class PhpDocumentor3ExpectedArrays
     {
         return [
             'phpdocumentor' => [
+                'use-cache' => true,
                 'paths'     => [
                     'output' => 'file://build/docs',
                     'cache'  => '/tmp/phpdoc-doc-cache'

--- a/tests/unit/phpDocumentor/Application/Commands/ConfigureCacheHandlerTest.php
+++ b/tests/unit/phpDocumentor/Application/Commands/ConfigureCacheHandlerTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Application\Commands;
+
+use Mockery as m;
+use org\bovigo\vfs\vfsStream;
+use phpDocumentor\Application\Configuration\ConfigurationFactory;
+use phpDocumentor\Application\Configuration\Factory\Strategy;
+use phpDocumentor\Uri;
+use PHPUnit_Framework_TestCase;
+use Stash\Pool;
+
+/**
+ * @coversDefaultClass phpDocumentor\Application\Commands\ConfigureCacheHandler
+ * @covers ::__construct
+ */
+final class ConfigureCacheHandlerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var m\MockInterface|Pool
+     */
+    private $pool;
+
+    /**
+     * @var ConfigurationFactory
+     */
+    private $configurationFactory;
+
+    /**
+     * @var ConfigureCacheHandler
+     */
+    private $fixture;
+
+    /**
+     * @var m\MockInterface
+     */
+    private $configStrategy;
+
+    /**
+     *
+     */
+    protected function setUp()
+    {
+        $this->pool = m::mock(Pool::class);
+        $this->configStrategy = m::mock(Strategy::class);
+        $this->configStrategy->shouldReceive('match')->andReturn(true);
+
+        $root = vfsStream::setup('dir');
+
+        vfsStream::newFile('foo.xml')->at($root)->withContent('<foo></foo>');
+        $uri = new Uri(vfsStream::url('dir/foo.xml'));
+
+        $this->configurationFactory = new ConfigurationFactory([$this->configStrategy], $uri);
+        $this->fixture = new ConfigureCacheHandler($this->pool, $this->configurationFactory);
+    }
+
+    /**
+     * @covers ::__invoke
+     */
+    public function testDisableCache()
+    {
+        $this->invokeTest(false);
+    }
+
+    /**
+     * @covers ::__invoke
+     */
+    public function testLeaveCache()
+    {
+        $this->invokeTest(true);
+    }
+
+    private function invokeTest($useCache)
+    {
+        $this->configStrategy->shouldReceive('convert')->andReturn([
+            'phpdocumentor' => [
+                'use-cache' => $useCache,
+                'paths' => [
+                    'cache' => './',
+                ],
+            ],
+        ]);
+
+        $this->pool->shouldReceive('flush')->times(!$useCache ? 1 : 0);
+        $this->pool->shouldReceive('getDriver->setOptions')->with(['path' => './']);
+
+        $this->fixture->__invoke(new ConfigureCache());
+    }
+}


### PR DESCRIPTION
This pr as a new command to the run-cli-command which reconfigures the cache pool.
Reintroduce usage of --force to disable cache usage
cache can be disabled from config by setting "use-cache" to false