### PR TITLE
Small grammar and formatting fixes

### DIFF
--- a/docs/references/phpdoc/tags/example.rst
+++ b/docs/references/phpdoc/tags/example.rst
@@ -15,7 +15,7 @@ Syntax
 
 or inline
 
-    {@example [location] [<start-line> [<number-of-lines>] ] [<description>]}
+    {\@example [location] [<start-line> [<number-of-lines>] ] [<description>]}
 
 Description
 -----------

--- a/docs/references/phpdoc/tags/filesource.rst
+++ b/docs/references/phpdoc/tags/filesource.rst
@@ -13,10 +13,10 @@ Description
 -----------
 
 The @filesource tag tells phpDocumentor to include the current file in the parsing
-output. As this only applies to the source code of the entire file MUST this
-tag be used in the file-level :term:`PHPDoc`. Any other location will be ignored.
+output. As this only applies to the source code of the entire file this tag MUST
+be used in the file-level :term:`PHPDoc`. Any other location will be ignored.
 
-When this tag is included will phpDocumentor compress the file contents and encode them
+When this tag is included phpDocumentor will compress the file contents and encode them
 using Base64 so that it can be handled by the transformer. Any template that
 is able to show the source code can then read the ``source`` sub-element in the
 associated ``file`` element in the :term:`Abstract Syntax Tree`.

--- a/docs/references/phpdoc/tags/internal.rst
+++ b/docs/references/phpdoc/tags/internal.rst
@@ -13,7 +13,7 @@ Syntax
 
 or inline:
 
-    {@internal [description]}}
+    {\@internal [description]}}
 
 The inline version of this tag may, contrary to other inline tags, contain
 text but also other inline tags. To increase readability and ease parsing, the

--- a/docs/references/phpdoc/tags/link.rst
+++ b/docs/references/phpdoc/tags/link.rst
@@ -18,7 +18,7 @@ Syntax
 
 or inline
 
-   {@link [URI] [<description>]}
+   {\@link [URI] [<description>]}
 
 Description
 -----------


### PR DESCRIPTION
- Fix grammar in @filesource tag documentation (noun before verb)

- Avoid creating mailto links by escaping @ outside code blocks