### PR TITLE
add test locations to PHPCS config file

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="continuousphp-phing-tasks">
+<ruleset name="phpDocumentor">
     <file>src</file>
-    <file>tests/unit</file>
     <file>tests/common</file>
+    <file>tests/unit</file>
 
     <description>PSR2 Coding standard</description>
     <rule ref="PSR2"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="continuousphp-phing-tasks">
+    <file>src</file>
+    <file>tests/unit</file>
+    <file>tests/common</file>
+
     <description>PSR2 Coding standard</description>
     <rule ref="PSR2"/>
 </ruleset>


### PR DESCRIPTION
Hey @mvriel,

we made a few upgrades on our PHPCS activity. Instead of specifying the test locations in the continuousphp pipeline, you can now simply add it to the phpcs.xml file. To not break any future builds, the old way is still supported.
If you decide to accept this PR, simply replace the 3 Paths in the pipeline config by one single path "phpcs.xml".

Check out my latest build with the new PHPCS config :)
https://continuousphp.com/git-hub/ppaulis/phpDocumentor2/build/0b2a996f-f3a2-4854-9f9c-c1f3e7913be4/output