### PR TITLE
Refactor copy action to v3

### DIFF
--- a/src/Application/ContainerDefinitions.php
+++ b/src/Application/ContainerDefinitions.php
@@ -241,7 +241,7 @@ return [
     Assets::class => \DI\object(FlySystemAssets::class)
         ->constructorParameter('filesystem', \DI\factory(function (ContainerInterface $c) {
             $filesystemFactory = $c->get(FileSystemFactory::class);
-            return $filesystemFactory->create(new Dsn('file://' . __DIR__ . '/../../data/templates'));
+            return $filesystemFactory->create(new Dsn('file://' . __DIR__ . '/../../data'));
         })),
 
     // Templates

--- a/src/Application/Renderer/Template/Action/CopyFile.php
+++ b/src/Application/Renderer/Template/Action/CopyFile.php
@@ -38,9 +38,13 @@ final class CopyFile implements Action
      */
     public static function create(array $parameters)
     {
+        Assert::allIsInstanceOf($parameters, Template\Parameter::class);
         Assert::keyExists($parameters, 'renderContext');
+        Assert::isInstanceOf($parameters['renderContext']->getValue(), RenderContext::class);
         Assert::keyExists($parameters, 'source');
+        Assert::string($parameters['source']->getValue());
         Assert::keyExists($parameters, 'destination');
+        Assert::string($parameters['destination']->getValue());
 
         return new static(
             $parameters['renderContext']->getValue(),
@@ -80,8 +84,8 @@ final class CopyFile implements Action
 
     private function __construct(RenderContext $renderContext, Path $source, Path $destination)
     {
-        $this->renderContext  = $renderContext;
-        $this->source      = $source;
-        $this->destination = $destination;
+        $this->renderContext = $renderContext;
+        $this->source        = $source;
+        $this->destination   = $destination;
     }
 }

--- a/src/Application/Renderer/Template/Action/CopyFileHandler.php
+++ b/src/Application/Renderer/Template/Action/CopyFileHandler.php
@@ -1,121 +1,84 @@
 <?php
 /**
- * phpDocumentor
+ * This file is part of phpDocumentor.
  *
- * PHP Version 5.4
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  *
- * @copyright 2010-2014 Mike van Riel / Naenius (http://www.naenius.com)
+ * @copyright 2010-2016 Mike van Riel<mike@phpdoc.org>
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
 
 namespace phpDocumentor\Application\Renderer\Template\Action;
 
-use League\Flysystem\Adapter\Local;
+use phpDocumentor\DomainModel\Path;
+use phpDocumentor\DomainModel\Renderer\Artefact;
+use phpDocumentor\DomainModel\Renderer\Asset;
+use phpDocumentor\DomainModel\Renderer\Asset\Folder;
 use phpDocumentor\DomainModel\Renderer\Template\Action;
 use phpDocumentor\DomainModel\Renderer\Template\ActionHandler;
-use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\Assert\Assert;
 
-/**
- * Writer containing file system operations.
- *
- * The Query part of the transformation determines the action, currently
- * supported is:
- *
- * * copy, copies a file or directory to the destination given in $artifact
- * * append, copies a file or directory and appends it to the destination given in $artifact; if $artifact does not
- *   exist yet it is created.
- */
 class CopyFileHandler implements ActionHandler
 {
     /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    public function __construct(Filesystem $filesystem)
-    {
-        $this->filesystem = $filesystem;
-    }
-
-    /**
      * Executes the activities that this Action represents.
      *
-     * @param CopyFile $action
+     * @param CopyFile|Action $action
      *
      * @return void
      */
     public function __invoke(Action $action)
     {
-        $source      = $this->getSourceLocation($action);
-        $destination = $this->getDestination($action);
-
-        Assert::fileExists($source);
-        if (!file_exists(dirname($destination))) {
-            mkdir(dirname($destination), 0777, true);
-        }
-        Assert::writable(dirname($destination));
-
-        $destinationFS = $action->getRenderContext()->getFilesystem();
-
-        if (is_file($source)) {
-            $stream = fopen($source, 'r+');
-            if ($destinationFS->has($destination)) {
-                $destinationFS->updateStream($destination, $stream);
-            } else {
-                $destinationFS->writeStream($destination, $stream);
-            }
-            fclose($stream);
-        } else {
-            $sourceFS = new \League\Flysystem\Filesystem(new Local($source));
-            foreach ($sourceFS->listContents('', true) as $path) {
-                $path = $path['path'];
-
-                if ($sourceFS->getMetadata($path)['type'] === 'dir') {
-                    continue;
-                }
-
-                if ($destinationFS->has($destination . '/' . $path)) {
-                    $destinationFS->updateStream($destination . '/' . $path, $sourceFS->readStream($path));
-                } else {
-                    $destinationFS->writeStream($destination . '/' . $path, $sourceFS->readStream($path));
-                }
-            }
-        }
+        $this->persistAssetAtLocation(
+            $action,
+            $this->fetchAsset($action, $action->getSource()),
+            $action->getDestination()
+        );
     }
 
     /**
      * @param CopyFile $action
      *
-     * @return string
+     * @return Asset
      */
-    private function getSourceLocation(Action $action)
+    private function fetchAsset(CopyFile $action, Path $source)
     {
-        $source = (string)$action->getSource();
-        if (! $this->filesystem->isAbsolutePath($source)) {
-            if (file_exists(getcwd() . '/' . $source)) {
-                return getcwd() . '/' . $source;
-            }
-            if (file_exists(__DIR__ . '/../../../../../' . $source)) {
-                return __DIR__ . '/../../../../../' . $source;
-            }
-
-            return __DIR__ . '/../../../../../data/' . $source;
-        }
-
-        return $source;
+        return $action->getRenderContext()->assets()->get($source);
     }
 
     /**
      * @param CopyFile $action
+     * @param Asset|Folder $asset
+     * @param Path $location
      *
-     * @return string
+     * @return void
      */
-    private function getDestination(Action $action)
+    private function persistAssetAtLocation(CopyFile $action, $asset, Path $location)
     {
-        $destination = $action->getRenderContext()->getDestination() . '/' . ltrim($action->getDestination(), '\\/');
+        if ($asset instanceof Folder) {
+            foreach ($asset as $path) {
+                $this->persistAssetAtLocation(
+                    $action,
+                    $this->fetchAsset($action, $path),
+                    new Path($location . substr($path, strlen((string)$asset->path())))
+                );
+            }
+            return;
+        }
 
-        return $destination;
+        $artefact = $this->createArtefact($location, $asset);
+        $action->getRenderContext()->artefacts()->persist($artefact);
+    }
+
+    /**
+     * @param Path $location
+     * @param Asset $asset
+     *
+     * @return Artefact
+     */
+    private function createArtefact(Path $location, Asset $asset)
+    {
+        return new Artefact($location, $asset->content());
     }
 }

--- a/src/DomainModel/Path.php
+++ b/src/DomainModel/Path.php
@@ -35,6 +35,18 @@ final class Path
     }
 
     /**
+     * Verifies if another Path object has the same identity as this one.
+     *
+     * @param Path $otherPath
+     *
+     * @return bool
+     */
+    public function equals(Path $otherPath)
+    {
+        return $this->path === (string)$otherPath;
+    }
+
+    /**
      * returns a string representation of the path.
      *
      * @return string

--- a/src/DomainModel/Renderer/Asset/Folder.php
+++ b/src/DomainModel/Renderer/Asset/Folder.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2016 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\DomainModel\Renderer\Asset;
+
+use phpDocumentor\DomainModel\Path;
+use Webmozart\Assert\Assert;
+
+class Folder extends \ArrayObject
+{
+    /**
+     * @var Path
+     */
+    private $path;
+
+    /**
+     * @param Path $path
+     * @param Path[] $locations
+     */
+    public function __construct(Path $path, array $locations)
+    {
+        Assert::allIsInstanceOf($locations, Path::class);
+
+        $this->path = $path;
+        parent::__construct($locations);
+    }
+
+    /**
+     * @return Path
+     */
+    public function path()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @param int|string $index
+     * @param Path $newval
+     */
+    public function offsetSet($index, $newval)
+    {
+        Assert::isInstanceOf($newval, Path::class);
+
+        parent::offsetSet($index, $newval);
+    }
+}

--- a/src/DomainModel/Renderer/Assets.php
+++ b/src/DomainModel/Renderer/Assets.php
@@ -38,13 +38,14 @@ interface Assets
     public function has(Path $location);
 
     /**
-     * Retrieves the asset with the given name.
+     * Retrieves an array with the requested asset or if the name matches multiple assets (such as with a folder)
+     * then it returns all of them.
      *
      * @param Path $location a location in one of the asset locations.
      *
      * @throws AssetNotFoundException if no asset could be found at that location.
      *
-     * @return Asset
+     * @return Asset[]
      */
     public function get(Path $location);
 }

--- a/tests/unit/Application/Renderer/Template/Action/CopyFileHandlerTest.php
+++ b/tests/unit/Application/Renderer/Template/Action/CopyFileHandlerTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2016 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Application\Renderer\Template\Action;
+
+use Mockery as m;
+use phpDocumentor\DomainModel\Path;
+use phpDocumentor\DomainModel\ReadModel\ReadModels;
+use phpDocumentor\DomainModel\Renderer\Artefact;
+use phpDocumentor\DomainModel\Renderer\Artefacts;
+use phpDocumentor\DomainModel\Renderer\Asset;
+use phpDocumentor\DomainModel\Renderer\AssetNotFoundException;
+use phpDocumentor\DomainModel\Renderer\Assets;
+use phpDocumentor\DomainModel\Renderer\RenderContext;
+use phpDocumentor\DomainModel\Renderer\Template\Parameter;
+
+/**
+ * @coversDefaultClass phpDocumentor\Application\Renderer\Template\Action\CopyFileHandler
+ * @covers ::<private>
+ */
+final class CopyFileHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var CopyFileHandler */
+    private $handler;
+
+    public function setUp()
+    {
+        $this->handler = new CopyFileHandler();
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function itShouldStoreAnAssetAsArtefact()
+    {
+        $assets = m::mock(Assets::class);
+        $artefacts = m::mock(Artefacts::class);
+
+        $renderContext = new RenderContext(new ReadModels([]), $assets, $artefacts);
+        $source = 'asset.jpg';
+        $destination = 'images/asset.jpg';
+
+        $action = $this->givenAnActionWith($renderContext, $source, $destination);
+        $assets->shouldReceive('get')->once()
+            ->with(
+                m::on(
+                    function (Path $value) use ($source) {
+                        return $value->equals(new Path($source));
+                    }
+                )
+            )
+            ->andReturn(new Asset('data'));
+
+        $artefacts->shouldReceive('persist')->once()
+            ->with(
+                m::on(
+                    function (Artefact $value) use ($destination) {
+                        $this->assertTrue($value->location()->equals(new Path($destination)));
+                        $this->assertTrue($value->content() === 'data');
+                        return true;
+                    }
+                )
+            );
+
+        $this->handler->__invoke($action);
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function itShouldStoreTheContentsOfAnAssetFolderAsArtefacts()
+    {
+        $assets = m::mock(Assets::class);
+        $artefacts = m::mock(Artefacts::class);
+
+        $renderContext = new RenderContext(new ReadModels([]), $assets, $artefacts);
+        $source = 'images';
+        $assetLocationInFolder = new Path('images/asset.jpg');
+        $destination = 'img';
+
+        $action = $this->givenAnActionWith($renderContext, $source, $destination);
+        $assets->shouldReceive('get')->once()
+            ->with(
+                m::on(
+                    function (Path $value) use ($source) {
+                        return $value->equals(new Path($source));
+                    }
+                )
+            )
+            ->andReturn(new Asset\Folder(new Path('images'), [$assetLocationInFolder]));
+
+        $assets->shouldReceive('get')->once()
+            ->with(
+                m::on(
+                    function (Path $value) use ($assetLocationInFolder) {
+                        return $value->equals($assetLocationInFolder);
+                    }
+                )
+            )
+            ->andReturn(new Asset('data'));
+
+        $artefacts->shouldReceive('persist')->once()
+            ->with(
+                m::on(
+                    function (Artefact $value) use ($destination) {
+                        $this->assertTrue($value->location()->equals(new Path($destination . '/asset.jpg')));
+                        $this->assertTrue($value->content() === 'data');
+                        return true;
+                    }
+                )
+            );
+
+        $this->handler->__invoke($action);
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function itShouldErrorIfTheAssetCouldNotBeFound()
+    {
+        $this->setExpectedException(AssetNotFoundException::class);
+
+        $assets = m::mock(Assets::class);
+        $artefacts = m::mock(Artefacts::class);
+
+        $renderContext = new RenderContext(new ReadModels([]), $assets, $artefacts);
+        $action = $this->givenAnActionWith($renderContext, 'asset.jpg', 'images/asset.jpg');
+        $assets->shouldReceive('get')->once()->andThrow(AssetNotFoundException::class);
+        $artefacts->shouldReceive('persist')->never();
+
+        $this->handler->__invoke($action);
+    }
+
+    /**
+     * @param $renderContext
+     * @param $source
+     * @param $destination
+     *
+     * @return static
+     */
+    private function givenAnActionWith($renderContext, $source, $destination)
+    {
+        return CopyFile::create([
+            'renderContext' => new Parameter('renderContext', $renderContext),
+            'source' => new Parameter('source', $source),
+            'destination' => new Parameter('destination', $destination)
+        ]);
+    }
+}

--- a/tests/unit/Application/Renderer/Template/Action/CopyFileTest.php
+++ b/tests/unit/Application/Renderer/Template/Action/CopyFileTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2016 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Application\Renderer\Template\Action;
+
+use Mockery as m;
+use phpDocumentor\DomainModel\Path;
+use phpDocumentor\DomainModel\ReadModel\ReadModels;
+use phpDocumentor\DomainModel\Renderer\Artefacts;
+use phpDocumentor\DomainModel\Renderer\Assets;
+use phpDocumentor\DomainModel\Renderer\RenderContext;
+use phpDocumentor\DomainModel\Renderer\Template\Parameter;
+
+/**
+ * @coversDefaultClass phpDocumentor\Application\Renderer\Template\Action\CopyFile
+ * @covers ::<private>
+ */
+final class CopyFileTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @covers ::create
+     * @covers ::getRenderContext
+     * @covers ::getSource
+     * @covers ::getDestination
+     */
+    public function itShouldCreateNewCommandWithContextSourceAndDestinationFromTemplateParameters()
+    {
+        $renderContext = new RenderContext(new ReadModels([]), m::mock(Assets::class), m::mock(Artefacts::class));
+        $source = 'asset.jpg';
+        $destination = 'images/asset.jpg';
+
+        $action = CopyFile::create([
+            'renderContext' => new Parameter('renderContext', $renderContext),
+            'source' => new Parameter('source', $source),
+            'destination' => new Parameter('destination', $destination)
+        ]);
+
+        $this->assertInstanceOf(CopyFile::class, $action);
+        $this->assertSame($renderContext, $action->getRenderContext());
+        $this->assertTrue($action->getSource()->equals(new Path($source)));
+        $this->assertTrue($action->getDestination()->equals(new Path($destination)));
+    }
+
+    /**
+     * @test
+     * @covers ::__toString
+     */
+    public function itShouldReturnALogLineWhenCastAsString()
+    {
+        $renderContext = new RenderContext(new ReadModels([]), m::mock(Assets::class), m::mock(Artefacts::class));
+        $source = 'asset.jpg';
+        $destination = 'images/asset.jpg';
+
+        $action = CopyFile::create([
+            'renderContext' => new Parameter('renderContext', $renderContext),
+            'source' => new Parameter('source', $source),
+            'destination' => new Parameter('destination', $destination)
+        ]);
+
+        $this->assertSame('Copied file asset.jpg to images/asset.jpg', (string)$action);
+    }
+
+    /**
+     * @test
+     * @covers ::create
+     */
+    public function itShouldCheckThatThePassedOptionsAreAllParameterObjects()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        CopyFile::create([
+            'renderContext' => new Parameter(
+                'renderContext',
+                new RenderContext(new ReadModels([]), m::mock(Assets::class), m::mock(Artefacts::class))
+            ),
+            'source' => new Parameter('source', 'asset.jpg'),
+            'destination' => 'images/asset.jpg' // introduce a mistake here
+        ]);
+    }
+
+    /**
+     * @test
+     * @covers ::create
+     */
+    public function itShouldCheckThatTheRenderContextExists()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        CopyFile::create([
+            'source' => new Parameter('source', 'asset.jpg'),
+            'destination' => new Parameter('destination', 'images/asset.jpg')
+        ]);
+    }
+
+    /**
+     * @test
+     * @covers ::create
+     */
+    public function itShouldCheckThatTheSourceParameterExists()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        CopyFile::create([
+            'renderContext' => new Parameter(
+                'renderContext',
+                new RenderContext(new ReadModels([]), m::mock(Assets::class), m::mock(Artefacts::class))
+            ),
+            'destination' => new Parameter('destination', 'images/asset.jpg')
+        ]);
+    }
+
+    /**
+     * @test
+     * @covers ::create
+     */
+    public function itShouldCheckThatTheDestinationParameterExists()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        CopyFile::create([
+            'renderContext' => new Parameter(
+                'renderContext',
+                new RenderContext(new ReadModels([]), m::mock(Assets::class), m::mock(Artefacts::class))
+            ),
+            'source' => new Parameter('source', 'asset.jpg'),
+        ]);
+    }
+
+    /**
+     * @test
+     * @covers ::create
+     */
+    public function itShouldCheckThatTheSourceIsAString()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        CopyFile::create([
+            'renderContext' => new Parameter(
+                'renderContext',
+                new RenderContext(new ReadModels([]), m::mock(Assets::class), m::mock(Artefacts::class))
+            ),
+            'source' => new Parameter('source', []),
+            'destination' => new Parameter('destination', 'images/asset.jpg')
+        ]);
+    }
+
+    /**
+     * @test
+     * @covers ::create
+     */
+    public function itShouldCheckThatTheRenderContextIsAValidRenderContextObject()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        CopyFile::create([
+            'renderContext' => new Parameter('renderContext', 'invalidRenderContext'),
+            'source' => new Parameter('source', 'asset.jpg'),
+            'destination' => new Parameter('destination', 'images/asset.jpg')
+        ]);
+    }
+
+    /**
+     * @test
+     * @covers ::create
+     */
+    public function itShouldCheckThatTheDestinationIsAString()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        CopyFile::create([
+            'renderContext' => new Parameter(
+                'renderContext',
+                new RenderContext(new ReadModels([]), m::mock(Assets::class), m::mock(Artefacts::class))
+            ),
+            'source' => new Parameter('source', 'asset.jpg'),
+            'destination' => new Parameter('destination', [])
+        ]);
+    }
+}

--- a/tests/unit/DomainModel/PathTest.php
+++ b/tests/unit/DomainModel/PathTest.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * phpDocumentor
+ * This file is part of phpDocumentor.
  *
- * PHP Version 5.5
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  *
- * @copyright 2010-2015 Mike van Riel / Naenius (http://www.naenius.com)
+ * @copyright 2010-2016 Mike van Riel<mike@phpdoc.org>
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
@@ -12,19 +13,34 @@
 namespace phpDocumentor\DomainModel;
 
 /**
- * Test case for Path
  * @coversDefaultClass phpDocumentor\DomainModel\Path
+ * @covers ::<private>
  */
-class PathTest extends \PHPUnit_Framework_TestCase
+final class PathTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @test
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testToString()
+    public function itCanContainALocationOnAStorageService()
     {
         $path = new Path('/my/Path');
 
-        $this->assertEquals('/my/Path', (string)$path);
+        $this->assertSame('/my/Path', (string)$path);
+    }
+
+    /**
+     * @test
+     * @covers ::equals
+     */
+    public function itCanCompareItselfToAnotherPath()
+    {
+        $subject = new Path('a');
+        $similar = new Path('a');
+        $dissimilar = new Path('b');
+
+        $this->assertTrue($subject->equals($similar));
+        $this->assertFalse($subject->equals($dissimilar));
     }
 }

--- a/tests/unit/DomainModel/Renderer/Asset/FolderTest.php
+++ b/tests/unit/DomainModel/Renderer/Asset/FolderTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2016 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\DomainModel\Renderer\Asset;
+
+use phpDocumentor\DomainModel\Path;
+
+/**
+ * @coversDefaultClass phpDocumentor\DomainModel\Renderer\Asset\Folder
+ * @covers ::<private>
+ */
+final class FolderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @coversNothing
+     */
+    public function itShouldBeACollection()
+    {
+        $folder = new Folder(new Path('images'), []);
+        $this->assertInstanceOf(\ArrayObject::class, $folder);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::path
+     */
+    public function itShouldExposeThePathForThisFolder()
+    {
+        $path = new Path('images');
+
+        $folder = new Folder($path, []);
+
+        $this->assertSame($path, $folder->path());
+    }
+
+    /**
+     * @test
+     * @covers ::offsetSet
+     */
+    public function itCanAddAdditionalPathsInThisFolder()
+    {
+        $folder = new Folder(new Path('images'), []);
+        $path = new Path('cats.png');
+
+        $folder[] = $path;
+
+        $this->assertSame($path, $folder[0]);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function itShouldErrorWhenTheConstructorReceivesSomethingOtherThanAPathObject()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        new Folder(new Path('images'), [new \stdClass()]);
+    }
+
+    /**
+     * @test
+     * @covers ::offsetSet
+     */
+    public function itShouldErrorWhenTheSomethingOtherThanAPathObjectIsAdded()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $folder = new Folder(new Path('images'), []);
+
+        $folder[] = new \stdClass();
+    }
+}

--- a/tests/unit/Infrastructure/Renderer/FlySystemAssetsTest.php
+++ b/tests/unit/Infrastructure/Renderer/FlySystemAssetsTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2016 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Infrastructure\Renderer;
+
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\File;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
+use Mockery as m;
+use phpDocumentor\DomainModel\Path;
+use phpDocumentor\DomainModel\Renderer\Asset;
+use phpDocumentor\DomainModel\Renderer\AssetNotFoundException;
+
+/**
+ * @coversDefaultClass phpDocumentor\Infrastructure\Renderer\FlySystemAssets
+ * @covers ::__construct
+ * @covers ::<private>
+ */
+final class FlySystemAssetsTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var FilesystemInterface|m\MockInterface */
+    private $filesystem;
+
+    /** @var FlySystemAssets */
+    private $assets;
+
+    public function setUp()
+    {
+        $this->filesystem = m::mock(FilesystemInterface::class);
+
+        $this->assets = new FlySystemAssets($this->filesystem);
+    }
+
+    /**
+     * @test
+     * @covers ::get
+     */
+    public function itShouldReturnAnAsset()
+    {
+        $location = new Path('image.jpg');
+        $file = m::mock(File::class);
+        $file->shouldReceive('isDir')->andReturn(false);
+        $file->shouldReceive('read')->andReturn('data');
+
+        $this->filesystem->shouldReceive('has')->andReturn(true);
+        $this->filesystem->shouldReceive('get')->andReturn($file);
+
+        $asset = $this->assets->get($location);
+
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertSame('data', $asset->content());
+    }
+
+    /**
+     * @test
+     * @covers ::get
+     */
+    public function itShouldReturnAFolder()
+    {
+        $location = new Path('images');
+        $file = m::mock(File::class);
+        $file->shouldReceive('isDir')->andReturn(true);
+
+        $this->filesystem->shouldReceive('has')->andReturn(true);
+        $this->filesystem->shouldReceive('get')->andReturn($file);
+        $this->filesystem->shouldReceive('listContents')
+            ->with((string)$location, true)
+            ->andReturn([['type' => 'file', 'path' => 'images/image.jpg']]);
+
+        $asset = $this->assets->get($location);
+
+        $this->assertInstanceOf(Asset\Folder::class, $asset);
+        $this->assertEquals([new Path('images/image.jpg')], $asset->getArrayCopy());
+    }
+
+    /**
+     * @test
+     * @covers ::get
+     */
+    public function itShouldNotReturnSubFoldersWhenRetrievingAFolder()
+    {
+        $location = new Path('images');
+        $file = m::mock(File::class);
+        $file->shouldReceive('isDir')->andReturn(true);
+
+        $this->filesystem->shouldReceive('has')->andReturn(true);
+        $this->filesystem->shouldReceive('get')->andReturn($file);
+        $this->filesystem->shouldReceive('listContents')
+            ->with((string)$location, true)
+            ->andReturn(
+                [
+                    ['type' => 'dir', 'path' => 'images/cats'],
+                    ['type' => 'file', 'path' => 'images/cats/cute.png'],
+                    ['type' => 'file', 'path' => 'images/image.jpg']
+                ]
+            );
+
+        $asset = $this->assets->get($location);
+
+        $this->assertInstanceOf(Asset\Folder::class, $asset);
+        $this->assertCount(2, $asset->getArrayCopy());
+        $this->assertEquals(new Path('images/cats/cute.png'), $asset->getArrayCopy()[0]);
+        $this->assertEquals(new Path('images/image.jpg'), $asset->getArrayCopy()[1]);
+    }
+
+    /**
+     * @test
+     * @covers ::get
+     */
+    public function itShouldErrorWhenFetchingAnAssetAndItDoesntExist()
+    {
+        $this->setExpectedException(AssetNotFoundException::class);
+        $this->filesystem->shouldReceive('has')->andReturn(false);
+        $this->filesystem->shouldReceive('get')->never();
+
+        $this->assets->get(new Path('image.jpg'));
+    }
+
+    /**
+     * @test
+     * @covers ::has
+     */
+    public function itShouldCheckWithFlysystemIfAnAssetExists()
+    {
+        $this->filesystem->shouldReceive('has')->with('image.jpg')->andReturn(true);
+        $this->filesystem->shouldReceive('has')->with('does-not-exist.jpg')->andReturn(false);
+
+        $this->assertTrue($this->assets->has(new Path('image.jpg')));
+        $this->assertFalse($this->assets->has(new Path('does-not-exist.jpg')));
+    }
+}


### PR DESCRIPTION
I have changed the CopyFile Action to make use of the new Artifact and
Asset abstractions; I had to make a little bit of extra effort to ensure
that it is compatible with previous editions of phpDocumentor. The
CopyFile Action will do a recursive copy of the files reported by
the Assets abstraction.

This also meant that I have expanded the Assets abstraction to include
the concept of a Folder; which means that you will return a collection
of Path objects that you can subsequently retrieve using the Assets
abstraction.

I have explicitly chosen to return Path objects and not complete
Asset objects because that might grow a bit large (being a recursive
action through the folder and all subfolders) and because that may
cause I/O that is never used because the user may not want to
retrieve all assets. In addition, memory would increase significantly
because all files would be stored in memory instead of retrieved
on a per Asset basis.
