### PR TITLE
Adds missing xsl namespace

### DIFF
--- a/data/templates/abstract/api-doc/docblock.xsl
+++ b/data/templates/abstract/api-doc/docblock.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml"
     xmlns:dbx="http://phpdoc.org/xsl/functions"
     xmlns:func="http://exslt.org/functions"
+    xmlns:php="http://php.net/xsl"
     extension-element-prefixes="func"
     exclude-result-prefixes="dbx">
 


### PR DESCRIPTION
Namespace php was not defined in docblock xsl. This caused critical errors
during processing the template. Resulting in an empty api-doc. Namespace is required
to be able to use the php: prefix.

fixes #1756