### PR TITLE
Restore {@inheritDoc} behavior

### DIFF
--- a/src/phpDocumentor/Descriptor/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/MethodDescriptor.php
@@ -250,11 +250,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
 
         /** @var ClassDescriptor|InterfaceDescriptor $parentClass|null */
         $parentClass = $associatedClass->getParent();
-        if ($parentClass) {
-            if (!$parentClass instanceof ClassDescriptor && !$parentClass instanceof Collection) {
-                return null;
-            }
-
+        if ($parentClass instanceof ClassDescriptor || $parentClass instanceof Collection) {
             // the parent of a class is always a class, but the parent of an interface is a collection of interfaces.
             $parents = $parentClass instanceof ClassDescriptor ? array($parentClass) : $parentClass->getAll();
             foreach ($parents as $parent) {


### PR DESCRIPTION
{@inheritDoc} now takes the summary and description from the interface that
was implemented.

This parially fixes #1505. I think `{@inheritDoc}` now works as before. But not fully as requested in #1505 

Refs #1724