### PR TITLE
fix bug with showing version tag

### DIFF
--- a/data/templates/clean/class.html.twig
+++ b/data/templates/clean/class.html.twig
@@ -244,6 +244,7 @@
                             </th>
                             <td>
                                 {% for tag in tags %}
+                                    {% if tag.version %}{{ tag.version }}{% endif %}
                                     {{ tag.description|markdown|raw }}
                                 {% endfor %}
                             </td>

--- a/data/templates/clean/elements/constant.html.twig
+++ b/data/templates/clean/elements/constant.html.twig
@@ -52,6 +52,7 @@
                         </th>
                         <td>
                             {% for tag in tags %}
+                                {% if tag.version %}{{ tag.version }}{% endif %}
                                 {{ tag.description|markdown|raw }}
                             {% endfor %}
                         </td>

--- a/data/templates/clean/elements/property.html.twig
+++ b/data/templates/clean/elements/property.html.twig
@@ -54,6 +54,7 @@
                         </th>
                         <td>
                             {% for tag in tags %}
+                                {% if tag.version %}{{ tag.version }}{% endif %}
                                 {{ tag.description|markdown|raw }}
                             {% endfor %}
                         </td>

--- a/data/templates/clean/file.html.twig
+++ b/data/templates/clean/file.html.twig
@@ -135,6 +135,7 @@
                                 </th>
                                 <td>
                                     {% for tag in tags %}
+                                        {% if tag.version %}{{ tag.version }}{% endif %}
                                         {{ tag.description|markdown|raw }}
                                     {% endfor %}
                                 </td>

--- a/data/templates/clean/interface.html.twig
+++ b/data/templates/clean/interface.html.twig
@@ -164,6 +164,7 @@
                             <th>{{ tagName }}</th>
                             <td>
                                 {% for tag in tags %}
+                                    {% if tag.version %}{{ tag.version }}{% endif %}
                                     {{ tag.description|markdown|raw }}
                                 {% endfor %}
                             </td>


### PR DESCRIPTION
This PR will fix issue #1762 where @version tags aren't shown in files, classes, interfaces, constants and properties. @version tags were shown in methods already