### PR TITLE
strip $ from property name in traits

### DIFF
--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -123,7 +123,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
         /** @var Tag\PropertyDescriptor $propertyTag */
         foreach ($propertyTags as $propertyTag) {
             $property = new PropertyDescriptor();
-            $property->setName($propertyTag->getVariableName());
+            $property->setName(ltrim($propertyTag->getVariableName(), '$'));
             $property->setDescription($propertyTag->getDescription());
             $property->setTypes($propertyTag->getTypes());
             $property->setParent($this);


### PR DESCRIPTION
The issue didn't occur in classes. Only in traits. With this PR I strip the $ sign off the property name, just like in ClassDescriptor.

This fixes the double $ and also the rendering of the source code as the superfluous $ sign also appeared in a css id selector name, which caused jquery to error