### PR TITLE
depend on newer fileset for symfony 3.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/console":                   "^2.8|~3.0",
         "symfony/validator":                 "^2.8|~3.0",
         "phpdocumentor/graphviz":            "^1.0",
-        "phpdocumentor/fileset":             "^1.0",
+        "phpdocumentor/fileset":             "dev-master",
         "phpdocumentor/reflection":          "dev-develop@dev",
         "phpdocumentor/reflection-docblock": "^3.0",
         "phpdocumentor/flyfinder":           "^1.0@dev",


### PR DESCRIPTION
when running a symfony 3.x project, you can't use phpdoc because fileset depends on a symfony 2.x version of symfony/finder.  This, paired with an update to phpdocumentor/fileset allows symfony 3.x projects to use phpdoc.