### PR TITLE
Fix bug #1767: Also find elements that are in the global namespace when using @see tag

### DIFF
--- a/src/phpDocumentor/Compiler/Linker/Linker.php
+++ b/src/phpDocumentor/Compiler/Linker/Linker.php
@@ -232,6 +232,13 @@ class Linker implements CompilerPassInterface
                 return $namespaceMember;
             }
 
+            // otherwise check if the element exists in the global namespace and if it exists, return that
+            $globalNamespaceContext = $this->getTypeWithGlobalNamespaceAsContext($fqsen);
+            $globalNamespaceMember  = $this->fetchElementByFqsen($globalNamespaceContext);
+            if ($globalNamespaceMember) {
+                return $globalNamespaceMember;
+            }
+
             // Otherwise we assume it is an undocumented class/interface/trait and return `\My\element` so
             // that the name containing the marker may be replaced by the class reference as string
             return $namespaceContext;
@@ -343,6 +350,17 @@ class Linker implements CompilerPassInterface
             : $namespace;
 
         return str_replace(self::CONTEXT_MARKER . '::', $fqnn . '\\', $fqsen);
+    }
+
+    /**
+     * Normalizes the given FQSEN as if the context marker represents the global namespace as parent.
+     *
+     * @param string             $fqsen
+     * @return string
+     */
+    protected function getTypeWithGlobalNamespaceAsContext($fqsen)
+    {
+        return str_replace(self::CONTEXT_MARKER . '::', '\\', $fqsen);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
@@ -39,7 +39,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
         $object = new \stdClass();
         $fqsenWithContextMarker  = '@context::MyMethod()';
         $fqsen  = '\phpDocumentor\Descriptor\MyClass::MyMethod()';
-        $container = m::mock(ClassDescriptor::class);
+        $container = m::mock('phpDocumentor\Descriptor\ClassDescriptor');
         $container->shouldReceive('getFullyQualifiedStructuralElementName')
             ->andReturn('\phpDocumentor\Descriptor\MyClass');
         $container->shouldReceive('getNamespace')->andReturn('\phpDocumentor\Descriptor');
@@ -62,7 +62,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
         $object = new \stdClass();
         $fqsenWithContextMarker  = '@context::MyClass';
         $fqsen = '\phpDocumentor\Descriptor\MyClass';
-        $container = m::mock(DescriptorAbstract::class);
+        $container = m::mock('phpDocumentor\Descriptor\DescriptorAbstract');
         $container->shouldReceive('getFullyQualifiedStructuralElementName')->andReturn('\phpDocumentor\Descriptor');
         $container->shouldReceive('getNamespace')->andReturn('\phpDocumentor\Descriptor');
 
@@ -84,7 +84,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
         $object = new \stdClass();
         $fqsenWithContextMarker  = '@context::MyClass';
         $fqsen = '\MyClass';
-        $container = m::mock(DescriptorAbstract::class);
+        $container = m::mock('phpDocumentor\Descriptor\DescriptorAbstract');
         $container->shouldReceive('getFullyQualifiedStructuralElementName')->andReturn('\phpDocumentor\Descriptor');
         $container->shouldReceive('getNamespace')->andReturn('\phpDocumentor\Descriptor');
 
@@ -105,7 +105,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
     public function testFindObjectAliasReturnsNamespaceContextWhenElementIsUndocumented()
     {
         $fqsenWithContextMarker  = '@context::MyClass';
-        $container = m::mock(NamespaceDescriptor::class);
+        $container = m::mock('phpDocumentor\Descriptor\NamespaceDescriptor');
         $container->shouldReceive('getFullyQualifiedStructuralElementName')->andReturn('\phpDocumentor\Descriptor');
         $container->shouldReceive('getNamespace')->andReturn('\phpDocumentor\Descriptor');
 
@@ -250,7 +250,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         list($childObject, $childFqsen) = $this->createMockDescriptorForResult($result);
 
-        $object = m::mock(DescriptorAbstract::class);
+        $object = m::mock('phpDocumentor\Descripto\DescriptorAbstract');
         $fqsen  = get_class($object);
         $object->shouldReceive('getChild')->atLeast()->once()->andReturn($childObject);
         $object->shouldReceive('setChild')->never();
@@ -284,7 +284,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         list($childObject, $childFqsen) = $this->createMockDescriptorForResult($result);
 
-        $object = m::mock(DescriptorAbstract::class);
+        $object = m::mock('phpDocumentor\Descriptor\DescriptorAbstract');
         $fqsen  = get_class($object);
         $object->shouldReceive('getChild')->atLeast()->once()->andReturn(array($childObject));
         $object->shouldReceive('setChild');
@@ -478,7 +478,7 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
      */
     protected function createMockUnknownTypeDescriptorForResult($result = null)
     {
-        $object = m::mock(UnknownTypeDescriptor::class);
+        $object = m::mock('phpDocumentor\Descriptor\Type\UnknownTypeDescriptor');
         $fqsen  = get_class($object);
 
         $object->shouldReceive('getName')->andReturn('\Name');


### PR DESCRIPTION
The linker treated elements that were referenced using a @see tag but were in the global namespace as undocumented because it was only looking at the namespace of the container class.
A check for the global namespace is added

The unit test has been extended to make sure code coverage is 100%. Also the incomplete tests are fixed.

The createMock... methods have been moved under the public methods (sorry, this messes up the diff a bit in github)