### PR TITLE
Correction in property fqsen

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,6 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b4c4a21e61177c5c41ca830b97440296",
     "content-hash": "a130907616ec35df4ea63f3eb004f545",
     "packages": [
         {
@@ -64,7 +63,7 @@
                 "cli",
                 "microframework"
             ],
-            "time": "2014-03-29 14:03:13"
+            "time": "2014-03-29T14:03:13+00:00"
         },
         {
             "name": "cilex/console-service-provider",
@@ -123,7 +122,7 @@
                 "service-provider",
                 "silex"
             ],
-            "time": "2012-12-19 10:50:58"
+            "time": "2012-12-19T10:50:58+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -191,7 +190,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -245,7 +244,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -287,7 +286,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2017-03-29 16:04:15"
+            "time": "2017-03-29T16:04:15+00:00"
         },
         {
             "name": "herrera-io/json",
@@ -349,7 +348,7 @@
                 "validate"
             ],
             "abandoned": "kherge/json",
-            "time": "2013-10-30 16:51:34"
+            "time": "2013-10-30T16:51:34+00:00"
         },
         {
             "name": "herrera-io/phar-update",
@@ -407,7 +406,7 @@
                 "update"
             ],
             "abandoned": true,
-            "time": "2013-10-30 17:23:01"
+            "time": "2013-10-30T17:23:01+00:00"
         },
         {
             "name": "jms/metadata",
@@ -458,7 +457,7 @@
                 "xml",
                 "yaml"
             ],
-            "time": "2016-12-05 10:18:33"
+            "time": "2016-12-05T10:18:33+00:00"
         },
         {
             "name": "jms/parser-lib",
@@ -493,7 +492,7 @@
                 "Apache2"
             ],
             "description": "A library for easily creating recursive-descent parsers.",
-            "time": "2012-11-18 18:08:43"
+            "time": "2012-11-18T18:08:43+00:00"
         },
         {
             "name": "jms/serializer",
@@ -563,7 +562,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2014-03-18 08:39:00"
+            "time": "2014-03-18T08:39:00+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -629,7 +628,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2016-01-25 15:43:01"
+            "time": "2016-01-25T15:43:01+00:00"
         },
         {
             "name": "kherge/version",
@@ -672,7 +671,7 @@
             "description": "A parsing and comparison library for semantic versioning.",
             "homepage": "http://github.com/kherge/Version",
             "abandoned": true,
-            "time": "2012-08-16 17:13:03"
+            "time": "2012-08-16T17:13:03+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -750,7 +749,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-03-13 07:08:03"
+            "time": "2017-03-13T07:08:03+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -795,7 +794,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-09-19 14:15:08"
+            "time": "2015-09-19T14:15:08+00:00"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -843,7 +842,7 @@
                 "sequence",
                 "set"
             ],
-            "time": "2015-05-17 12:39:23"
+            "time": "2015-05-17T12:39:23+00:00"
         },
         {
             "name": "phpdocumentor/fileset",
@@ -886,7 +885,7 @@
                 "fileset",
                 "phpdoc"
             ],
-            "time": "2013-08-06 21:07:42"
+            "time": "2013-08-06T21:07:42+00:00"
         },
         {
             "name": "phpdocumentor/graphviz",
@@ -927,7 +926,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2016-02-02 13:00:08"
+            "time": "2016-02-02T13:00:08+00:00"
         },
         {
             "name": "phpdocumentor/reflection",
@@ -981,20 +980,20 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2016-05-21 08:42:32"
+            "time": "2016-05-21T08:42:32+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
                 "shasum": ""
             },
             "require": {
@@ -1030,7 +1029,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -1080,7 +1079,7 @@
                 "php",
                 "type"
             ],
-            "time": "2015-07-25 16:39:46"
+            "time": "2015-07-25T16:39:46+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -1126,7 +1125,7 @@
                 "container",
                 "dependency injection"
             ],
-            "time": "2013-11-22 08:30:29"
+            "time": "2013-11-22T08:30:29+00:00"
         },
         {
             "name": "psr/log",
@@ -1173,7 +1172,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -1222,7 +1221,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2017-03-06 16:42:24"
+            "time": "2017-03-06T16:42:24+00:00"
         },
         {
             "name": "symfony/config",
@@ -1278,7 +1277,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/console",
@@ -1339,7 +1338,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-26 01:38:53"
+            "time": "2017-04-26T01:38:53+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1396,7 +1395,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-19 19:56:30"
+            "time": "2017-04-19T19:56:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1456,7 +1455,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-26 16:56:54"
+            "time": "2017-04-26T16:56:54+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1505,7 +1504,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/finder",
@@ -1554,7 +1553,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1613,7 +1612,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/process",
@@ -1662,7 +1661,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -1711,7 +1710,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/translation",
@@ -1775,7 +1774,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/validator",
@@ -1848,7 +1847,7 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "twig/twig",
@@ -1910,7 +1909,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-04-20 17:39:48"
+            "time": "2017-04-20T17:39:48+00:00"
         },
         {
             "name": "zendframework/zend-cache",
@@ -1970,7 +1969,7 @@
                 "cache",
                 "zf2"
             ],
-            "time": "2015-06-03 15:31:59"
+            "time": "2015-06-03T15:31:59+00:00"
         },
         {
             "name": "zendframework/zend-config",
@@ -2027,7 +2026,7 @@
                 "config",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:00"
+            "time": "2015-06-03T15:32:00+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -2072,7 +2071,7 @@
                 "eventmanager",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:01"
+            "time": "2015-06-03T15:32:01+00:00"
         },
         {
             "name": "zendframework/zend-filter",
@@ -2130,7 +2129,7 @@
                 "filter",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:01"
+            "time": "2015-06-03T15:32:01+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
@@ -2193,7 +2192,7 @@
                 "i18n",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:01"
+            "time": "2015-06-03T15:32:01+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -2247,7 +2246,7 @@
                 "json",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:01"
+            "time": "2015-06-03T15:32:01+00:00"
         },
         {
             "name": "zendframework/zend-math",
@@ -2299,7 +2298,7 @@
                 "math",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:02"
+            "time": "2015-06-03T15:32:02+00:00"
         },
         {
             "name": "zendframework/zend-serializer",
@@ -2351,7 +2350,7 @@
                 "serializer",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:02"
+            "time": "2015-06-03T15:32:02+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -2401,7 +2400,7 @@
                 "servicemanager",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:02"
+            "time": "2015-06-03T15:32:02+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -2457,7 +2456,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2015-06-03 15:32:03"
+            "time": "2015-06-03T15:32:03+00:00"
         },
         {
             "name": "zetacomponents/base",
@@ -2520,7 +2519,7 @@
             ],
             "description": "The Base package provides the basic infrastructure that all packages rely on. Therefore every component relies on this package.",
             "homepage": "https://github.com/zetacomponents",
-            "time": "2014-09-19 03:28:34"
+            "time": "2014-09-19T03:28:34+00:00"
         },
         {
             "name": "zetacomponents/document",
@@ -2571,7 +2570,7 @@
             ],
             "description": "The Document components provides a general conversion framework for different semantic document markup languages like XHTML, Docbook, RST and similar.",
             "homepage": "https://github.com/zetacomponents",
-            "time": "2013-12-19 11:40:00"
+            "time": "2013-12-19T11:40:00+00:00"
         }
     ],
     "packages-dev": [
@@ -2648,7 +2647,7 @@
                 "symfony",
                 "testing"
             ],
-            "time": "2014-04-20 18:32:33"
+            "time": "2014-04-20T18:32:33+00:00"
         },
         {
             "name": "behat/gherkin",
@@ -2707,7 +2706,7 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2016-10-30 11:50:56"
+            "time": "2016-10-30T11:50:56+00:00"
         },
         {
             "name": "behat/transliterator",
@@ -2751,7 +2750,7 @@
                 "slug",
                 "transliterator"
             ],
-            "time": "2017-04-04 11:38:05"
+            "time": "2017-04-04T11:38:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2805,7 +2804,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -2850,7 +2849,7 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11 14:41:42"
+            "time": "2015-05-11T14:41:42+00:00"
         },
         {
             "name": "mikey179/vfsStream",
@@ -2896,7 +2895,7 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2016-07-18 14:02:57"
+            "time": "2016-07-18T14:02:57+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -3024,7 +3023,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02 20:05:34"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3086,7 +3085,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3133,7 +3132,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -3174,7 +3173,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -3223,7 +3222,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -3272,7 +3271,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27 10:12:30"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -3344,7 +3343,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06 05:18:07"
+            "time": "2017-02-06T05:18:07+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -3400,7 +3399,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -3464,7 +3463,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -3516,7 +3515,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -3566,7 +3565,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3633,7 +3632,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -3684,7 +3683,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -3737,7 +3736,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03 07:41:43"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3772,7 +3771,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -3847,7 +3846,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-12-04 22:32:15"
+            "time": "2014-12-04T22:32:15+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -3900,7 +3899,7 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -3963,7 +3962,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-26 01:38:53"
+            "time": "2017-04-26T01:38:53+00:00"
         },
         {
             "name": "symfony/expression-language",
@@ -4012,7 +4011,7 @@
             ],
             "description": "Symfony ExpressionLanguage Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01 14:31:55"
+            "time": "2017-05-01T14:31:55+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -4065,7 +4064,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -4114,7 +4113,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01 14:31:55"
+            "time": "2017-05-01T14:31:55+00:00"
         }
     ],
     "aliases": [],

--- a/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
@@ -145,14 +145,6 @@ class ElementsIndexBuilder implements CompilerPassInterface
      */
     protected function getIndexKey($element)
     {
-        $key = $element->getFullyQualifiedStructuralElementName();
-
-        // properties should have an additional $ before the property name
-        if ($element instanceof PropertyInterface) {
-            list($fqcn, $propertyName) = explode('::', $key);
-            $key = $fqcn . '::$' . $propertyName;
-        }
-
-        return $key;
+        return $element->getFullyQualifiedStructuralElementName();
     }
 }

--- a/src/phpDocumentor/Descriptor/PropertyDescriptor.php
+++ b/src/phpDocumentor/Descriptor/PropertyDescriptor.php
@@ -41,7 +41,7 @@ class PropertyDescriptor extends DescriptorAbstract implements
     public function setParent($parent)
     {
         $this->setFullyQualifiedStructuralElementName(
-            $parent->getFullyQualifiedStructuralElementName() . '::' . $this->getName()
+            $parent->getFullyQualifiedStructuralElementName() . '::$' . $this->getName()
         );
 
         $this->parent = $parent;

--- a/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
@@ -261,7 +261,7 @@ class ElementsIndexBuilderTest extends \PHPUnit_Framework_TestCase
         $file1->getClasses()->add($classDescriptor1);
 
         $classPropertyDescriptor1 = new PropertyDescriptor();
-        $classPropertyDescriptor1->setFullyQualifiedStructuralElementName('My\Space\Class1::PROPERTY');
+        $classPropertyDescriptor1->setFullyQualifiedStructuralElementName('My\Space\Class1::$property');
         $classDescriptor1->getProperties()->add($classPropertyDescriptor1);
 
         $file2 = $this->project->getFiles()->get(1);
@@ -270,16 +270,15 @@ class ElementsIndexBuilderTest extends \PHPUnit_Framework_TestCase
         $file2->getClasses()->add($classDescriptor2);
 
         $classPropertyDescriptor2 = new PropertyDescriptor();
-        $classPropertyDescriptor2->setFullyQualifiedStructuralElementName('My\Space\Class2::PROPERTY');
+        $classPropertyDescriptor2->setFullyQualifiedStructuralElementName('My\Space\Class2::$property');
         $classDescriptor2->getProperties()->add($classPropertyDescriptor2);
 
         $this->fixture->execute($this->project);
 
         $elements = $this->project->getIndexes()->get('elements')->getAll();
         $this->assertCount(4, $elements);
-        // note the addition of the dollar sign in front of the property name
         $this->assertSame(
-            array('My\Space\Class1', 'My\Space\Class1::$PROPERTY', 'My\Space\Class2', 'My\Space\Class2::$PROPERTY'),
+            array('My\Space\Class1', 'My\Space\Class1::$property', 'My\Space\Class2', 'My\Space\Class2::$property'),
             array_keys($elements)
         );
         $this->assertSame(

--- a/tests/unit/phpDocumentor/Descriptor/PropertyDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/PropertyDescriptorTest.php
@@ -74,6 +74,27 @@ class PropertyDescriptorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers phpDocumentor\Descriptor\PropertyDescriptor::getTypes
+     * @covers phpDocumentor\Descriptor\PropertyDescriptor::setTypes
+     */
+    public function testSetAndGetTypesWhenVarIsPresent()
+    {
+        // Arrange
+        $typesCollection = new Collection();
+        $varTagDescriptor = new VarDescriptor('var');
+        $varTagDescriptor->setTypes($typesCollection);
+        $varCollection = new Collection(array($varTagDescriptor));
+        $this->fixture->getTags()->clear();
+        $this->fixture->getTags()->set('var', $varCollection);
+
+        // Act
+        $result = $this->fixture->getTypes();
+
+        // Assert
+        $this->assertSame($typesCollection, $result);
+    }
+
+    /**
      * @covers phpDocumentor\Descriptor\PropertyDescriptor::getDefault
      * @covers phpDocumentor\Descriptor\PropertyDescriptor::setDefault
      */
@@ -194,6 +215,17 @@ class PropertyDescriptorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers phpDocumentor\Descriptor\PropertyDescriptor::getVar
+     */
+    public function testVarTagsWhenNoneArePresent()
+    {
+        $varCollection = new Collection();
+        $result = $this->fixture->getVar();
+
+        $this->assertEquals($varCollection, $result);
+    }
+
+    /**
      * @covers phpDocumentor\Descriptor\PropertyDescriptor::getAuthor
      * @covers phpDocumentor\Descriptor\DescriptorAbstract::getAuthor
      */
@@ -251,6 +283,45 @@ class PropertyDescriptorTest extends \PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertSame($copyrightCollection, $result);
+    }
+
+    /**
+     * @covers phpDocumentor\Descriptor\PropertyDescriptor::setParent
+     */
+    public function testFqsenHasDollarSignWhenParentIsSet()
+    {
+        $this->whenFixtureHasPropertyInParentClassWithSameName($this->fixture->getName());
+        $this->assertSame('::$property', $this->fixture->getFullyQualifiedStructuralElementName());
+    }
+
+    /**
+     * @covers phpDocumentor\Descriptor\PropertyDescriptor::setParent
+     * @covers phpDocumentor\Descriptor\PropertyDescriptor::getParent
+     */
+    public function testSettingAndGettingAParent()
+    {
+        $this->whenFixtureHasPropertyInParentClassWithSameName($this->fixture->getName());
+        $this->assertInstanceOf('phpDocumentor\Descriptor\ClassDescriptor', $this->fixture->getParent());
+    }
+
+    /**
+     * @covers phpDocumentor\Descriptor\PropertyDescriptor::getInheritedElement
+     */
+    public function testGettingAnInheritedElement()
+    {
+        $this->whenFixtureHasPropertyInParentClassWithSameName($this->fixture->getName());
+
+        $inheritedProperty = $this->fixture->getInheritedElement();
+
+        $this->assertSame($inheritedProperty->getName(), $this->fixture->getName());
+    }
+
+    /**
+     * @covers phpDocumentor\Descriptor\PropertyDescriptor::getInheritedElement
+     */
+    public function testGettingAnInheritedElementWhenThereIsNone()
+    {
+        $this->assertNull($this->fixture->getInheritedElement());
     }
 
     /**


### PR DESCRIPTION
One of the issues that was discovered regarding the @see tag (see investigation described in https://github.com/phpDocumentor/phpDocumentor2/issues/1079) was a missing $ sign in the property fqsen displayed from a regular @see tag.

The displayed fqsen would be something like this: \Namespace\Classname::property instead of \Namespace\Classname::$property.

When inspecting the ProjectDescriptor, I noticed that the fqsens in the PropertyDescriptors were missing the $ sign as well. However, the property elements in the ProjectDescriptor - Indexes - Elements did have a $ sign. That $ sign was added in the ElementsIndexBuilder, but that didn't fix the fqsen in the PropertyDescriptor which is being used to display the property name in a @see or @link tag. With this commit the $ sign is added in the correct place.

Also the test coverage of PropertyDescriptor is completed to 100%

Using the test script described in issue 1079 I checked if this change only affected the displayed fqsen in the regular @see tags and if all other texts and links stayed the same (still containing the same bugs as well). This is the case.