### PR TITLE
Issue 1726 internal see links broken

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
@@ -46,6 +46,7 @@ class MethodAssembler extends AssemblerAbstract
     public function create($data)
     {
         $methodDescriptor = new MethodDescriptor();
+        $methodDescriptor->setNamespace('\\' . $data->getNamespace());
         $this->mapReflectorToDescriptor($data, $methodDescriptor);
 
         $this->assembleDocBlock($data->getDocBlock(), $methodDescriptor);

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * phpDocumentor
+ * This file is part of phpDocumentor.
  *
- * PHP Version 5.3
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  *
- * @copyright 2010-2014 Mike van Riel / Naenius (http://www.naenius.com)
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssembler.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * phpDocumentor
+ * This file is part of phpDocumentor.
  *
- * PHP Version 5.3
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  *
- * @copyright 2010-2014 Mike van Riel / Naenius (http://www.naenius.com)
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
-
 namespace phpDocumentor\Descriptor\Builder\Reflector;
 
 use phpDocumentor\Descriptor\PropertyDescriptor;
@@ -29,6 +29,7 @@ class PropertyAssembler extends AssemblerAbstract
     public function create($data)
     {
         $propertyDescriptor = new PropertyDescriptor();
+        $propertyDescriptor->setNamespace('\\' . $data->getNamespace());
         $propertyDescriptor->setFullyQualifiedStructuralElementName($data->getName());
         $propertyDescriptor->setName($data->getShortName());
         $propertyDescriptor->setVisibility($data->getVisibility() ?: 'public');

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssembler.php
@@ -9,6 +9,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
+
 namespace phpDocumentor\Descriptor\Builder\Reflector;
 
 use phpDocumentor\Descriptor\PropertyDescriptor;

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/MethodAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/MethodAssemblerTest.php
@@ -9,6 +9,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
+
 namespace phpDocumentor\Descriptor\Builder\Reflector;
 
 use phpDocumentor\Descriptor\ArgumentDescriptor;

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssemblerTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+namespace phpDocumentor\Descriptor\Builder\Reflector;
+
+use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\ClassReflector\PropertyReflector;
+use Mockery as m;
+
+class PropertyAssemblerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var PropertyAssembler $fixture */
+    protected $fixture;
+
+    /** @var ProjectDescriptorBuilder|m\MockInterface */
+    protected $builderMock;
+
+    /**
+     * Creates a new fixture to test with.
+     */
+    protected function setUp()
+    {
+        $this->builderMock = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
+        $this->builderMock->shouldReceive('buildDescriptor')->andReturn(null);
+
+        $this->fixture = new PropertyAssembler();
+        $this->fixture->setBuilder($this->builderMock);
+    }
+
+    /**
+     * @covers phpDocumentor\Descriptor\Builder\Reflector\PropertyAssembler::create
+     */
+    public function testCreatePropertyDescriptorFromReflector()
+    {
+        // Arrange
+        $namespace    = 'Namespace';
+        $propertyName   = 'property';
+
+        $propertyReflectorMock = $this->givenAPropertyReflector(
+            $namespace,
+            $propertyName,
+            $this->givenADocBlockObject(true)
+        );
+
+        // Act
+        $descriptor = $this->fixture->create($propertyReflectorMock);
+
+        // Assert
+        $expectedFqsen = $namespace . '\\$' . $propertyName;
+        $this->assertSame($expectedFqsen, $descriptor->getFullyQualifiedStructuralElementName());
+        $this->assertSame($propertyName, $descriptor->getName());
+        $this->assertSame('\\' . $namespace, $descriptor->getNamespace());
+        $this->assertSame('protected', $descriptor->getVisibility());
+        $this->assertSame(false, $descriptor->isStatic());
+    }
+
+    /**
+     * Creates a sample property reflector for the tests with the given data.
+     *
+     * @param string                             $namespace
+     * @param string                             $propertyName
+     * @param DocBlock|m\MockInterface           $docBlockMock
+     *
+     * @return PropertyReflector|m\MockInterface
+     */
+    protected function givenAPropertyReflector($namespace, $propertyName, $docBlockMock = null)
+    {
+        $propertyReflectorMock = m::mock('phpDocumentor\Reflection\PropertyReflector');
+        $propertyReflectorMock->shouldReceive('getName')->andReturn($namespace . '\\$' . $propertyName);
+        $propertyReflectorMock->shouldReceive('getShortName')->andReturn($propertyName);
+        $propertyReflectorMock->shouldReceive('getNamespace')->andReturn($namespace);
+        $propertyReflectorMock->shouldReceive('getDocBlock')->andReturn($docBlockMock);
+        $propertyReflectorMock->shouldReceive('getLinenumber')->andReturn(128);
+        $propertyReflectorMock->shouldReceive('getVisibility')->andReturn('protected');
+        $propertyReflectorMock->shouldReceive('getDefault')->andReturn(null);
+        $propertyReflectorMock->shouldReceive('isStatic')->andReturn(false);
+
+        return $propertyReflectorMock;
+    }
+
+    /**
+     * Generates a DocBlock object with applicable defaults for these tests.
+     *
+     * @return DocBlock|m\MockInterface
+     */
+    protected function givenADocBlockObject($withTags)
+    {
+        $docBlockDescription = new DocBlock\Description('This is an example description');
+
+        $docBlockMock = m::mock('phpDocumentor\Reflection\DocBlock');
+        $docBlockMock->shouldReceive('getTags')->andReturn(array());
+        $docBlockMock->shouldReceive('getShortDescription')->andReturn('This is a example description');
+        $docBlockMock->shouldReceive('getLongDescription')->andReturn($docBlockDescription);
+
+        if ($withTags) {
+            $docBlockMock->shouldReceive('getTagsByName')->andReturnUsing(function ($param) {
+                $tag = m::mock('phpDocumentor\Reflection\DocBlock\Tag');
+
+                $tag->shouldReceive('isVariadic')->once()->andReturn(true);
+                $tag->shouldReceive('getVariableName')->andReturn('variableName');
+                $tag->shouldReceive('getTypes')->andReturn(array());
+                $tag->shouldReceive('getDescription');
+
+                return array($tag);
+            });
+        } else {
+            $docBlockMock->shouldReceive('getTagsByName')->andReturn(array());
+        }
+
+        return $docBlockMock;
+    }
+}

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssemblerTest.php
@@ -9,6 +9,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
+
 namespace phpDocumentor\Descriptor\Builder\Reflector;
 
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;


### PR DESCRIPTION
The inline relative see tags in docblocks of properties and methods could not be resolved for elements in the same namespace as the container class because the property and method descriptors were missing their namespace. This way the context was not complete for the see tags and the relevant element could not be found. With this change the property and method assemblers will set the namespace in the descriptors.

This PR fixes one of the issues that were discovered in the test of issue 1079. This leaves two more bugs to fix.

The code coverage of the two classes is completed to 100%

The result is visually tested with the clean and responsive templates. The links work again and no negative side effects have been noticed.

refs #1726, #1079 