### PR TITLE
Support `@method static int foo()` syntax for magic methods

### DIFF
--- a/docs/references/phpdoc/tags/method.rst
+++ b/docs/references/phpdoc/tags/method.rst
@@ -6,13 +6,13 @@ The @method allows a class to know which 'magic' methods are callable.
 Syntax
 ------
 
-    @method [return type] [name]([[type] [parameter]<, ...>]) [<description>]
+    @method [[static] return type] [name]([[type] [parameter]<, ...>]) [<description>]
 
 Description
 -----------
 
 The @method tag is used in situation where a class contains the ``__call()``
-magic method and defines some definite uses.
+or ``__callStatic()`` magic method and defines some definite uses.
 
 An example of this is a child class whose parent has a __call() to have dynamic
 getters or setters for predefined properties. The child knows which getters and
@@ -25,6 +25,11 @@ return value by including those types in the signature.
 
 When the intended method does not have a return value then the return type MAY
 be omitted; in which case 'void' is implied.
+
+If the intended method is static, the ``static`` keyword can be placed before
+the return type to communicate that.
+There must be a return type, ``static`` on its own would mean that the method
+returns an instance of the child class which the method is called on.
 
 @method tags MUST NOT be used in a :term:`PHPDoc` that is not associated with
 a *class* or *interface*.
@@ -54,6 +59,7 @@ Examples
      * @method string getString()
      * @method void setInteger(integer $integer)
      * @method setString(integer $integer)
+     * @method static string staticGetter()
      */
     class Child extends Parent
     {

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
@@ -38,6 +38,7 @@ class MethodAssembler extends AssemblerAbstract
         $descriptor = new MethodDescriptor($data->getName());
         $descriptor->setDescription($data->getDescription());
         $descriptor->setMethodName($data->getMethodName());
+        $descriptor->setStatic($data->isStatic());
 
         $response = new ReturnDescriptor('return');
         $response->setTypes($this->builder->buildDescriptor(new Collection($data->getTypes())));

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -203,6 +203,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
             $method = new MethodDescriptor();
             $method->setName($methodTag->getMethodName());
             $method->setDescription($methodTag->getDescription());
+            $method->setStatic($methodTag->isStatic());
             $method->setParent($this);
 
             $returnTags = $method->getTags()->get('return', new Collection());

--- a/src/phpDocumentor/Descriptor/Tag/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/Tag/MethodDescriptor.php
@@ -22,6 +22,9 @@ class MethodDescriptor extends TagDescriptor
 
     protected $response;
 
+    /** @var bool */
+    protected $static;
+
     public function __construct($name)
     {
         parent::__construct($name);
@@ -75,5 +78,21 @@ class MethodDescriptor extends TagDescriptor
     public function getResponse()
     {
         return $this->response;
+    }
+
+    /**
+     * @param bool $static
+     */
+    public function setStatic($static)
+    {
+        $this->static = $static;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStatic()
+    {
+        return $this->static;
     }
 }

--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -76,6 +76,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
             $method = new MethodDescriptor();
             $method->setName($methodTag->getMethodName());
             $method->setDescription($methodTag->getDescription());
+            $method->setStatic($methodTag->isStatic());
             $method->setParent($this);
 
             $methods->add($method);

--- a/tests/ReferenceImplementation.php
+++ b/tests/ReferenceImplementation.php
@@ -73,6 +73,7 @@ namespace My\Space {
      * @author Mike van Riel <mike.vanriel@naenius.com>
      * @package Class
      * @method string myMagicMethod(\stdClass $argument1) This is a description.
+     * @method static string myStaticMagicMethod(\stdClass $argument1) This is a description.
      * @property string $myMagicProperty This is a description.
      */
     class SuperClass implements SubInterface

--- a/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
@@ -361,8 +361,10 @@ class ClassDescriptorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers phpDocumentor\Descriptor\ClassDescriptor::getMagicMethods
+     * @dataProvider provideMagicMethodProperties
+     * @param bool $isStatic
      */
-    public function testGetMagicMethods()
+    public function testGetMagicMethods($isStatic)
     {
         $methodName  = 'methodName';
         $description = 'description';
@@ -377,7 +379,7 @@ class ClassDescriptorTest extends \PHPUnit_Framework_TestCase
         $methodMock->shouldReceive('getDescription')->andReturn($description);
         $methodMock->shouldReceive('getResponse')->andReturn($response);
         $methodMock->shouldReceive('getArguments')->andReturn($arguments);
-        $methodMock->shouldReceive('isStatic')->andReturn(true);
+        $methodMock->shouldReceive('isStatic')->andReturn($isStatic);
 
         $this->fixture->getTags()->get('method', new Collection())->add($methodMock);
 
@@ -390,7 +392,7 @@ class ClassDescriptorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($methodName, $magicMethod->getName());
         $this->assertEquals($description, $magicMethod->getDescription());
         $this->assertEquals($response, $magicMethod->getResponse());
-        $this->assertEquals(true, $magicMethod->isStatic());
+        $this->assertEquals($isStatic, $magicMethod->isStatic());
 
         $mock = m::mock('phpDocumentor\Descriptor\ClassDescriptor');
         $mock->shouldReceive('getMagicMethods')->andReturn(new Collection(array('magicMethods')));
@@ -398,6 +400,21 @@ class ClassDescriptorTest extends \PHPUnit_Framework_TestCase
 
         $magicMethods = $this->fixture->getMagicMethods();
         $this->assertCount(2, $magicMethods);
+    }
+
+    /**
+     * Provider to test different properties for a class magic method
+     * (provides isStatic)
+     * @return bool[][]
+     */
+    public function provideMagicMethodProperties()
+    {
+        return array(
+            // Instance magic method (default)
+            array(false),
+            // Static magic method
+            array(true),
+        );
     }
 
     /**

--- a/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
@@ -377,6 +377,7 @@ class ClassDescriptorTest extends \PHPUnit_Framework_TestCase
         $methodMock->shouldReceive('getDescription')->andReturn($description);
         $methodMock->shouldReceive('getResponse')->andReturn($response);
         $methodMock->shouldReceive('getArguments')->andReturn($arguments);
+        $methodMock->shouldReceive('isStatic')->andReturn(true);
 
         $this->fixture->getTags()->get('method', new Collection())->add($methodMock);
 
@@ -389,6 +390,7 @@ class ClassDescriptorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($methodName, $magicMethod->getName());
         $this->assertEquals($description, $magicMethod->getDescription());
         $this->assertEquals($response, $magicMethod->getResponse());
+        $this->assertEquals(true, $magicMethod->isStatic());
 
         $mock = m::mock('phpDocumentor\Descriptor\ClassDescriptor');
         $mock->shouldReceive('getMagicMethods')->andReturn(new Collection(array('magicMethods')));

--- a/tests/unit/phpDocumentor/Descriptor/TraitDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/TraitDescriptorTest.php
@@ -101,6 +101,7 @@ class TraitDescriptorTest extends \PHPUnit_Framework_TestCase
     {
         $mockMethodDescriptor = m::mock('phpDocumentor\Descriptor\Tag\MethodDescriptor');
         $mockMethodDescriptor->shouldReceive('getMethodName')->andReturn('Sample');
+        $mockMethodDescriptor->shouldReceive('isStatic')->andReturn(false);
         $mockMethodDescriptor->shouldReceive('getDescription')->andReturn('Sample description');
 
         $methodCollection = new Collection(array($mockMethodDescriptor));
@@ -111,6 +112,7 @@ class TraitDescriptorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(1, $magicMethodsCollection->count());
         $this->assertSame('Sample', $magicMethodsCollection[0]->getName());
         $this->assertSame('Sample description', $magicMethodsCollection[0]->getDescription());
+        $this->assertSame(false, $magicMethodsCollection[0]->isStatic());
         $this->assertSame($this->fixture, $magicMethodsCollection[0]->getParent());
     }
 

--- a/tests/unit/phpDocumentor/Descriptor/TraitDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/TraitDescriptorTest.php
@@ -96,12 +96,14 @@ class TraitDescriptorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers phpDocumentor\Descriptor\TraitDescriptor::getMagicMethods
+     * @dataProvider provideMagicMethodProperties
+     * @param bool $isStatic
      */
-    public function testMagicMethodsReturnsExpectedCollectionWithTags()
+    public function testMagicMethodsReturnsExpectedCollectionWithTags($isStatic)
     {
         $mockMethodDescriptor = m::mock('phpDocumentor\Descriptor\Tag\MethodDescriptor');
         $mockMethodDescriptor->shouldReceive('getMethodName')->andReturn('Sample');
-        $mockMethodDescriptor->shouldReceive('isStatic')->andReturn(false);
+        $mockMethodDescriptor->shouldReceive('isStatic')->andReturn($isStatic);
         $mockMethodDescriptor->shouldReceive('getDescription')->andReturn('Sample description');
 
         $methodCollection = new Collection(array($mockMethodDescriptor));
@@ -112,8 +114,23 @@ class TraitDescriptorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(1, $magicMethodsCollection->count());
         $this->assertSame('Sample', $magicMethodsCollection[0]->getName());
         $this->assertSame('Sample description', $magicMethodsCollection[0]->getDescription());
-        $this->assertSame(false, $magicMethodsCollection[0]->isStatic());
+        $this->assertSame($isStatic, $magicMethodsCollection[0]->isStatic());
         $this->assertSame($this->fixture, $magicMethodsCollection[0]->getParent());
+    }
+
+    /**
+     * Provider to test different properties for a trait magic method
+     * (provides isStatic)
+     * @return bool[][]
+     */
+    public function provideMagicMethodProperties()
+    {
+        return array(
+            // Instance magic method (default)
+            array(false),
+            // Static magic method
+            array(true),
+        );
     }
 
     /**


### PR DESCRIPTION
After this change, phpdoc API documentation generated from `@method` tags will indicate that the method is static the phpdoc tag was of the form `@method static Type foo()`

Do this by reading isStatic() from ReflectionDocBlock

- This was added to ReflectionDocBlock before the docblock 2.0.0 release,
  so it should be safe to assume that it's available (excluding beta versions of ReflectionDocBlock)

This was tested locally with the following snippet 
(verified generated HTML API documentation was correct and static):

    /** 
     * @method static int fooStatic() implicitly a void
     */  
    class MyClass{}

Add a draft of updating the docs for static method support.
- Not sure how to indicate the first version where phpdocumentor supports static method
- Feel free to suggest the exact wording and layout, or fix it after this PR

For issue #822