### PR TITLE
Issue-1079 and issue-1026 Fix @see links in responsive template

### DIFF
--- a/data/templates/responsive/elements/common.xsl
+++ b/data/templates/responsive/elements/common.xsl
@@ -167,11 +167,14 @@
     <xsl:template match="tag[@name = 'see' or @name = 'uses']" mode="tabular">
         <xsl:variable name="url">
             <xsl:choose>
-                <xsl:when test="not(contains(@link, 'http'))">
+                <xsl:when test="php:function('phpDocumentor\Plugin\Core\Xslt\Extension::typeOfElement', string(@link)) = 'documented'">
                     <xsl:value-of select="concat($root, php:function('phpDocumentor\Plugin\Core\Xslt\Extension::path', string(@link)))" />
                 </xsl:when>
-                <xsl:otherwise>
+                <xsl:when test="php:function('phpDocumentor\Plugin\Core\Xslt\Extension::typeOfElement', string(@link)) = 'url'">
                     <xsl:value-of select="@link" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="'#'" />
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>

--- a/data/templates/responsive/elements/common.xsl
+++ b/data/templates/responsive/elements/common.xsl
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:php="http://php.net/xsl">
     <xsl:output indent="yes" method="html" />
 
     <!-- Concatenate items with links with a given separator, based on: http://symphony-cms.com/download/xslt-utilities/view/22517/-->
@@ -164,8 +164,37 @@
         </tr>
     </xsl:template>
 
-    <xsl:template match="tag[@name = 'license' or @name = 'link' or @name = 'see' or @name = 'uses' or @name = 'author']" mode="tabular">
+    <xsl:template match="tag[@name = 'see' or @name = 'uses']" mode="tabular">
+        <xsl:variable name="url">
+            <xsl:choose>
+                <xsl:when test="not(contains(@link, 'http'))">
+                    <xsl:value-of select="concat($root, php:function('phpDocumentor\Plugin\Core\Xslt\Extension::path', string(@link)))" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="@link" />
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
         <tr>
+            <th><xsl:value-of select="@name"/></th>
+            <td>
+                <a href="{$url}">
+                    <xsl:choose>
+                        <xsl:when test="@description = ''">
+                            <xsl:value-of select="@link" disable-output-escaping="yes" />
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="@description" disable-output-escaping="yes" />
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </a>
+            </td>
+        </tr>
+    </xsl:template>
+
+    <xsl:template match="tag[@name = 'license' or @name = 'link' or @name = 'author']" mode="tabular">
+         <tr>
             <th><xsl:value-of select="@name"/></th>
             <td>
                 <a href="{@link}">

--- a/src/phpDocumentor/Transformer/Router/StandardRouter.php
+++ b/src/phpDocumentor/Transformer/Router/StandardRouter.php
@@ -88,7 +88,7 @@ class StandardRouter extends RouterAbstract
         // if this is a link to an external page; return that URL
         $this[] = new Rule(
             function ($node) {
-                return is_string($node) && (substr($node, 0, 7) == 'http://' || substr($node, 0, 7) == 'https://');
+                return is_string($node) && (substr($node, 0, 7) == 'http://' || substr($node, 0, 8) == 'https://');
             },
             function ($node) { return $node; }
         );

--- a/tests/unit/phpDocumentor/Plugin/Core/Xslt/ExtensionTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Xslt/ExtensionTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Plugin\Core\Xslt;
+
+use Mockery as m;
+
+/**
+ * Test class for \phpDocumentor\Plugin\Core\Xslt\Extension.
+ *
+ * @covers \phpDocumentor\Plugin\Core\Xslt\Extension
+ */
+class ExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers \phpDocumentor\Plugin\Core\Xslt\Extension::markdown
+     */
+    public function testMarkdownWithString()
+    {
+        $text = '`this is markdown`';
+
+        $result = Extension::markdown($text);
+
+        $this->assertSame("<p><code>this is markdown</code></p>", $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Plugin\Core\Xslt\Extension::markdown
+     */
+    public function testMarkdownReturnsInputUnchangedWhenInputIsNotString()
+    {
+        $text = [];
+
+        $result = Extension::markdown($text);
+
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Plugin\Core\Xslt\Extension::path
+     */
+    public function testPathWithExternalLink()
+    {
+        $elementList = m::mock('phpDocumentor\Descriptor\Collection');
+        $elementList->shouldReceive('get')->andReturn(null);
+
+        $projectDescriptorBuilder = $this->givenAProjectDescriptorBuilder($elementList);
+
+        $rule = m::mock('phpDocumentor\Transformer\Router');
+        $rule->shouldReceive('generate')->andReturn('http://phpdoc.org');
+        $router = $this->givenARouter($rule);
+
+        Extension::$descriptorBuilder = $projectDescriptorBuilder;
+        Extension::$routers = $router;
+        $result = Extension::path('http://phpdoc.org');
+
+        $this->assertSame('http://phpdoc.org', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Plugin\Core\Xslt\Extension::path
+     */
+    public function testPathWithUndocumentedElement()
+    {
+        $elementList = m::mock('phpDocumentor\Descriptor\Collection');
+        $elementList->shouldReceive('get')->andReturn(null);
+
+        $projectDescriptorBuilder = $this->givenAProjectDescriptorBuilder($elementList);
+
+        $router = $this->givenARouter(null);
+
+        Extension::$descriptorBuilder = $projectDescriptorBuilder;
+        Extension::$routers = $router;
+        $result = Extension::path('undocumented');
+
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Plugin\Core\Xslt\Extension::path
+     */
+    public function testPathWithDocumentedElement()
+    {
+        $elementList = m::mock('phpDocumentor\Descriptor\Collection');
+        $element = m::mock('phpDocumentor\Descriptor\Collection');
+        $element->shouldReceive('offsetExists')->andReturn(true);
+        $element->shouldReceive('offsetGet');
+        $elementList->shouldReceive('get')->andReturn($element);
+
+        $projectDescriptorBuilder = $this->givenAProjectDescriptorBuilder($elementList);
+
+        $rule = m::mock('phpDocumentor\Transformer\Router');
+        $rule->shouldReceive('generate')->andReturn('/classes/my.namespace.class.html');
+
+        $router = $this->givenARouter($rule);
+
+        Extension::$descriptorBuilder = $projectDescriptorBuilder;
+        Extension::$routers = $router;
+        $result = Extension::path('\\my\\namespace\\class');
+
+        $this->assertSame('classes/my.namespace.class.html', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Plugin\Core\Xslt\Extension::typeOfElement
+     */
+    public function testTypeOfElementWithUrl()
+    {
+        $elementList = m::mock('phpDocumentor\Descriptor\Collection');
+        $elementList->shouldReceive('get')->andReturn(null);
+
+        $projectDescriptorBuilder = $this->givenAProjectDescriptorBuilder($elementList);
+
+        $router = $this->givenARouter(null);
+
+        Extension::$descriptorBuilder = $projectDescriptorBuilder;
+        Extension::$routers = $router;
+        $result = Extension::typeOfElement('http://phpdoc.org');
+
+        $this->assertSame('url', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Plugin\Core\Xslt\Extension::typeOfElement
+     */
+    public function testTypeOfElementWithUndocumentedElement()
+    {
+        $elementList = m::mock('phpDocumentor\Descriptor\Collection');
+        $elementList->shouldReceive('get')->andReturn(null);
+
+        $projectDescriptorBuilder = $this->givenAProjectDescriptorBuilder($elementList);
+
+        $router = $this->givenARouter(null);
+
+        Extension::$descriptorBuilder = $projectDescriptorBuilder;
+        Extension::$routers = $router;
+        $result = Extension::typeOfElement('undocumented element');
+
+        $this->assertSame('undocumented', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Plugin\Core\Xslt\Extension::typeOfElement
+     */
+    public function testTypeOfElementWithDocumentedElement()
+    {
+        $elementList = m::mock('phpDocumentor\Descriptor\Collection');
+        $element = m::mock('phpDocumentor\Descriptor\Collection');
+        $element->shouldReceive('offsetExists')->with('my\\namespace')->andReturn(false);
+        $element->shouldReceive('offsetExists')->with('~\\my\\namespace')->andReturn(true);
+        $element->shouldReceive('offsetGet')->with('~\\my\\namespace')->andReturn('the namespace descriptor');
+        $elementList->shouldReceive('get')->andReturn($element);
+
+        $projectDescriptorBuilder = $this->givenAProjectDescriptorBuilder($elementList);
+
+        $rule = m::mock('phpDocumentor\Transformer\Router');
+        $rule->shouldReceive('generate')->andReturn('/classes/my.namespace.class.html');
+
+        $router = $this->givenARouter(null);
+
+        Extension::$descriptorBuilder = $projectDescriptorBuilder;
+        Extension::$routers = $router;
+        $result = Extension::typeOfElement('my\\namespace');
+
+        $this->assertSame('documented', $result);
+    }
+
+    private function givenAProjectDescriptorBuilder($elementList)
+    {
+        $projectDescriptor = m::mock('\phpDocumentor\Descriptor\ProjectDescriptor');
+        $projectDescriptor->shouldReceive('getIndexes')->andReturn($elementList);
+        $projectDescriptorBuilder = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
+        $projectDescriptorBuilder->shouldReceive('getProjectDescriptor')->andReturn($projectDescriptor);
+        return $projectDescriptorBuilder;
+    }
+
+    private function givenARouter($rule)
+    {
+        $queue = m::mock('phpDocumentor\Transformer\Router\Queue');
+        $router = m::mock('phpDocumentor\Transformer\Router\StandardRouter');
+        $queue->shouldReceive('insert');
+        $router->shouldReceive('match')->andReturn($rule);
+        return $router;
+    }
+}

--- a/tests/unit/phpDocumentor/Transformer/Router/StandardRouterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/StandardRouterTest.php
@@ -65,6 +65,7 @@ class StandardRouterTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers phpDocumentor\Transformer\Router\StandardRouter::configure
+     * @covers phpDocumentor\Transformer\Router\StandardRouter::__construct
      * @covers phpDocumentor\Transformer\Router\RouterAbstract::__construct
      * @covers phpDocumentor\Transformer\Router\RouterAbstract::configure
      * @covers phpDocumentor\Transformer\Router\RouterAbstract::match


### PR DESCRIPTION
Regular @see links were not visible as text and not working as links in the responsive template.
The links were treated the same way as the license, link and author tags, but because they may reference structural elements, this doesn't always work. With this PR the @see and @uses tags are dealt with in a separate template. And when there is no 'http' in the link, they will be processed using the already existing xslt extension: **phpDocumentor\Plugin\Core\Xslt\Extension::path**

This fix has been tested in responsive template with regular @see tags in docblocks of class, method, property and constant. @see tags referencing structural elements and @see tags referencing websites were used in testing. @uses don't work well, but that is because they don't end up in the structure.xml correctly. This is another bug for which I will make an issue.

Regular @see tags referencing a class using a namespace alias don't work either. That was the last bug I found in my investigation in issue-1079. For that I will make a separate PR. 