### PR TITLE
Issue 1079 regular relative see tags to other class

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssembler.php
@@ -14,6 +14,7 @@ namespace phpDocumentor\Descriptor\Builder\Reflector\Tags;
 use phpDocumentor\Compiler\Linker\Linker;
 use phpDocumentor\Descriptor\Builder\Reflector\AssemblerAbstract;
 use phpDocumentor\Descriptor\Tag\SeeDescriptor;
+use phpDocumentor\Reflection\DocBlock\Context;
 use phpDocumentor\Reflection\DocBlock\Tag\SeeTag;
 use phpDocumentor\Reflection\DocBlock\Type\Collection;
 
@@ -47,7 +48,6 @@ class SeeAssembler extends AssemblerAbstract
             && $reference !== '$this'
             && $reference[0] !== '\\'
         ) {
-            // TODO: move this to the ReflectionDocBlock component
             // Expand FQCN part of the FQSEN
             $referenceParts = explode('::', $reference);
 
@@ -66,9 +66,9 @@ class SeeAssembler extends AssemblerAbstract
     }
 
     /**
-     * @param $context
-     * @param $referenceParts
-     * @return mixed
+     * @param Context $context
+     * @param string[] $referenceParts
+     * @return array The returned array will consist of a Collection object with the type, and strings for methods, etc.
      */
     private function setFirstReferencePartAsType($context, $referenceParts)
     {
@@ -84,15 +84,15 @@ class SeeAssembler extends AssemblerAbstract
     /**
      * When you have a relative reference to a class, we need to check if this class exists in the namespace aliases
      *
-     * @param $reference
-     * @param $context
+     * @param string $reference
+     * @param Context $context
      * @return bool
      */
     private function referenceIsNamespaceAlias($reference, $context)
     {
         /** @var \phpDocumentor\Reflection\DocBlock\Context $context*/
         foreach ($context->getNamespaceAliases() as $alias) {
-            if (substr($alias, -strlen($reference), strlen($reference)) === $reference) {
+            if (substr($alias, -strlen($reference))) {
                 return true;
             }
         }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssembler.php
@@ -92,7 +92,7 @@ class SeeAssembler extends AssemblerAbstract
     {
         /** @var \phpDocumentor\Reflection\DocBlock\Context $context*/
         foreach ($context->getNamespaceAliases() as $alias) {
-            if (substr($alias, -strlen($reference))) {
+            if (substr($alias, -strlen($reference)) === $reference) {
                 return true;
             }
         }

--- a/src/phpDocumentor/Transformer/Router/Renderer.php
+++ b/src/phpDocumentor/Transformer/Router/Renderer.php
@@ -212,6 +212,7 @@ class Renderer
             && $url[0] != '/'
             && (strpos($url, 'http://') !== 0)
             && (strpos($url, 'https://') !== 0)
+            && (strpos($url, 'ftp://') !== 0)
         ) {
             $url = $this->convertToRootPath($url);
         }

--- a/src/phpDocumentor/Transformer/Router/StandardRouter.php
+++ b/src/phpDocumentor/Transformer/Router/StandardRouter.php
@@ -88,7 +88,7 @@ class StandardRouter extends RouterAbstract
         // if this is a link to an external page; return that URL
         $this[] = new Rule(
             function ($node) {
-                return is_string($node) && (substr($node, 0, 7) == 'http://' || substr($node, 0, 8) == 'https://');
+                return is_string($node) && (substr($node, 0, 7) == 'http://' || substr($node, 0, 8) == 'https://' || substr($node, 0, 6) == 'ftp://');
             },
             function ($node) { return $node; }
         );

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssemblerTest.php
@@ -18,7 +18,8 @@ use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 /**
  * Test class for phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler
  *
- * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::<private>
+ * @coversDefaultClass \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler
+ * @covers ::<private>
  */
 class SeeAssemblerTest extends \PHPUnit_Framework_TestCase
 {
@@ -39,7 +40,7 @@ class SeeAssemblerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::create
+     * @covers ::create
      */
     public function testCreateSeeDescriptorFromSeeTagWhenReferenceIsRelativeClassnameNotInNamespaceAliasses()
     {
@@ -63,7 +64,7 @@ class SeeAssemblerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::create
+     * @covers ::create
      */
     public function testCreateSeeDescriptorFromSeeTagWhenReferenceIsRelativeClassnameInNamespaceAliases()
     {
@@ -87,7 +88,7 @@ class SeeAssemblerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::create
+     * @covers ::create
      * @dataProvider provideReferences
      */
     public function testCreateSeeDescriptorFromSeeTagWhenReferenceIsUrl($reference)
@@ -111,7 +112,7 @@ class SeeAssemblerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::create
+     * @covers ::create
      */
     public function testCreateSeeDescriptorFromSeeTagWhenReferenceHasMultipleParts()
     {

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssemblerTest.php
@@ -48,7 +48,7 @@ class SeeAssemblerTest extends \PHPUnit_Framework_TestCase
         $name = 'see';
         $description = 'a see tag';
         $reference = 'ReferenceClass';
-        $context = $this->givenAContext([]);
+        $context = $this->givenAContext([$reference => '\My\Namespace\Alias\AnotherClass']);
         $docBlock = $this->givenADocBlock($context);
 
         $seeTagMock = $this->givenASeeTag($name, $description, $reference, $docBlock);

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/SeeAssemblerTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Descriptor\Builder\Reflector\Tags;
+
+use Mockery as m;
+use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
+
+/**
+ * Test class for phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler
+ *
+ * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::<private>
+ */
+class SeeAssemblerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var SeeAssembler $fixture */
+    protected $fixture;
+
+    /** @var ProjectDescriptorBuilder|m\MockInterface */
+    protected $builderMock;
+
+    /**
+     * Creates a new fixture to test with.
+     */
+    protected function setUp()
+    {
+        $this->builderMock = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
+        $this->fixture = new SeeAssembler();
+        $this->fixture->setBuilder($this->builderMock);
+    }
+
+    /**
+     * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::create
+     */
+    public function testCreateSeeDescriptorFromSeeTagWhenReferenceIsRelativeClassnameNotInNamespaceAliasses()
+    {
+        // Arrange
+        $name = 'see';
+        $description = 'a see tag';
+        $reference = 'ReferenceClass';
+        $context = $this->givenAContext([]);
+        $docBlock = $this->givenADocBlock($context);
+
+        $seeTagMock = $this->givenASeeTag($name, $description, $reference, $docBlock);
+
+        // Act
+        $descriptor = $this->fixture->create($seeTagMock);
+
+        // Assert
+        $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
+        $this->assertSame('@context::' . $reference, $descriptor->getReference());
+        $this->assertSame([], $descriptor->getErrors()->getAll());
+    }
+
+    /**
+     * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::create
+     */
+    public function testCreateSeeDescriptorFromSeeTagWhenReferenceIsRelativeClassnameInNamespaceAliases()
+    {
+        // Arrange
+        $name = 'see';
+        $description = 'a see tag';
+        $reference = 'ReferenceClass';
+        $context = $this->givenAContext([$reference => '\My\Namespace\Alias\ReferenceClass']);
+        $docBlock = $this->givenADocBlock($context);
+
+        $seeTagMock = $this->givenASeeTag($name, $description, $reference, $docBlock);
+
+        // Act
+        $descriptor = $this->fixture->create($seeTagMock);
+
+        // Assert
+        $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
+        $this->assertSame('\\My\\Namespace\Alias\\' . $reference, $descriptor->getReference());
+        $this->assertSame([], $descriptor->getErrors()->getAll());
+    }
+
+    /**
+     * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::create
+     * @dataProvider provideReferences
+     */
+    public function testCreateSeeDescriptorFromSeeTagWhenReferenceIsUrl($reference)
+    {
+        // Arrange
+        $name = 'see';
+        $description = 'a see tag';
+        $context = $this->givenAContext([]);
+        $docBlock = $this->givenADocBlock($context);
+
+        $seeTagMock = $this->givenASeeTag($name, $description, $reference, $docBlock);
+
+        // Act
+        $descriptor = $this->fixture->create($seeTagMock);
+
+        // Assert
+        $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
+        $this->assertSame($reference, $descriptor->getReference());
+        $this->assertSame([], $descriptor->getErrors()->getAll());
+    }
+
+    /**
+     * @covers \phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler::create
+     */
+    public function testCreateSeeDescriptorFromSeeTagWhenReferenceHasMultipleParts()
+    {
+        // Arrange
+        $name = 'see';
+        $description = 'a see tag';
+        $reference = 'ReferenceClass::$property';
+        $context = $this->givenAContext(['ReferenceClass' => '\My\Namespace\Alias\ReferenceClass']);
+        $docBlock = $this->givenADocBlock($context);
+
+        $seeTagMock = $this->givenASeeTag($name, $description, $reference, $docBlock);
+
+        // Act
+        $descriptor = $this->fixture->create($seeTagMock);
+
+        // Assert
+        $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
+        $this->assertSame('\\My\\Namespace\Alias\\' . $reference, $descriptor->getReference());
+        $this->assertSame([], $descriptor->getErrors()->getAll());
+    }
+
+    protected function givenASeeTag($name, $description, $reference, $docBlock)
+    {
+        $seeTagMock = m::mock('phpDocumentor\Reflection\DocBlock\Tag\SeeTag');
+        $seeTagMock->shouldReceive('getName')->andReturn($name);
+        $seeTagMock->shouldReceive('getDescription')->andReturn($description);
+        $seeTagMock->shouldReceive('getReference')->andReturn($reference);
+        $seeTagMock->shouldReceive('getDocBlock')->andReturn($docBlock);
+
+        return $seeTagMock;
+    }
+
+    protected function givenADocBlock($context)
+    {
+        $docBlockMock = m::mock('phpDocumentor\Reflection\DocBlock');
+        $docBlockMock->shouldReceive('getContext')->andReturn($context);
+
+        return $docBlockMock;
+    }
+
+    protected function givenAContext($aliases)
+    {
+        $context = m::mock('phpDocumentor\Reflection\DocBlock\Context');
+        $context->shouldReceive('getNamespace')->andReturn('\My\Namespace');
+        $context->shouldReceive('getNamespaceAliases')->andReturn($aliases);
+
+        return $context;
+    }
+
+    public function provideReferences()
+    {
+        return [
+            ['http://phpdoc.org'],
+            ['https://phpdoc.org'],
+            ['ftp://phpdoc.org'],
+            ['$this'],
+            ['self'],
+            ['\My\Namespace\Class']
+        ];
+    }
+}

--- a/tests/unit/phpDocumentor/Transformer/Router/RendererTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/RendererTest.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer\Router;
+
+use Mockery as m;
+use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\Type\CollectionDescriptor;
+
+/**
+ * Test class for phpDocumentor\Transformer\Router\Renderer
+ *
+ * @covers \phpDocumentor\Transformer\Router\Renderer::<protected>
+ */
+class RendererTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Queue
+     */
+    private $originalQueue;
+
+    /**
+     * @var Renderer
+     */
+    private $renderer;
+
+    public function setUp()
+    {
+        $this->originalQueue = m::mock('phpDocumentor\Transformer\Router\Queue');
+        $this->renderer = new Renderer($this->originalQueue);
+    }
+
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::__construct
+     * @covers \phpDocumentor\Transformer\Router\Renderer::getRouters
+     */
+    public function testConstructRenderer()
+    {
+        $result = $this->renderer->getRouters();
+
+        $this->assertSame($this->originalQueue, $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::__construct
+     * @covers \phpDocumentor\Transformer\Router\Renderer::getRouters
+     * @covers \phpDocumentor\Transformer\Router\Renderer::setRouters
+     */
+    public function testGetAndSetRouters()
+    {
+        $rule = $this->givenARule('http://phpdoc.org');
+        $newQueue = [$this->givenAQueue($rule)];
+        $this->renderer->setRouters($newQueue);
+
+        $result = $this->renderer->getRouters();
+
+        $this->assertNotSame($this->originalQueue, $result);
+        $this->assertSame($newQueue, $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::__construct
+     * @covers \phpDocumentor\Transformer\Router\Renderer::getDestination
+     * @covers \phpDocumentor\Transformer\Router\Renderer::setDestination
+     */
+    public function testGetAndSetDestination()
+    {
+        $this->renderer->setDestination('destination');
+
+        $this->assertSame('destination', $this->renderer->getDestination());
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     */
+    public function testRenderWithFqsenAndRepresentationUrl()
+    {
+        $rule = $this->givenARule('/classes/My.Namespace.Class.html');
+        $queue = $this->givenAQueue($rule);
+        $queue->shouldReceive('match')->andReturn($rule);
+        $this->renderer->setRouters($queue);
+        $result = $this->renderer->render('\My\Namespace\Class', 'url');
+
+        $this->assertSame('classes/My.Namespace.Class.html', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     */
+    public function testRenderWithCollectionOfFqsensAndRepresentationUrl()
+    {
+        $rule = $this->givenARule('/classes/My.Namespace.Class.html');
+        $queue = $this->givenAQueue($rule);
+        $queue->shouldReceive('match')->andReturn($rule);
+        $this->renderer->setRouters($queue);
+        $this->renderer->setDestination('/root/of/project');
+        $collection = new Collection(['\My\Namespace\Class']);
+        $result = $this->renderer->render($collection, 'url');
+
+        $this->assertSame(['../../../classes/My.Namespace.Class.html'], $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     */
+    public function testRenderWithUrlAndNoRuleMatch()
+    {
+        $rule = $this->givenARule('@');
+        $queue = $this->givenAQueue($rule);
+        $queue->shouldReceive('match')->with('file://phpdoc')->andReturn($rule);
+        $queue->shouldReceive('match')->with('@')->andReturn(null);
+        $this->renderer->setRouters($queue);
+        $result = $this->renderer->render('file://phpdoc', 'url');
+
+        $this->assertSame(null, $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     */
+    public function testConvertToRootPathWithUrlAndAtSignInRelativePath()
+    {
+        $rule = $this->givenARule('@Class::$property');
+        $queue = $this->givenAQueue($rule);
+        $queue->shouldReceive('match')->with('@Class::$property')->andReturn($rule);
+        $queue->shouldReceive('match')->with('@')->andReturn($rule);
+        $this->renderer->setRouters($queue);
+        $result = $this->renderer->convertToRootPath('@Class::$property');
+
+        $this->assertSame('@Class::$property', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     */
+    public function testRenderWithCollectionDescriptorWithNameIsNotArrayAndRepresentationUrl()
+    {
+        $rule = $this->givenARule('ClassDescriptor');
+        $queue = $this->givenAQueue($rule);
+        $queue->shouldReceive('match')->andReturn($rule);
+        $this->renderer->setRouters($queue);
+        $collectionDescriptor = $this->givenACollectionDescriptor('class');
+        $collectionDescriptor->setKeyTypes(['ClassDescriptor']);
+        $result = $this->renderer->render($collectionDescriptor, 'url');
+
+        $this->assertSame('ClassDescriptor&lt;ClassDescriptor,ClassDescriptor&gt;', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     */
+    public function testRenderWithCollectionDescriptorWithNameIsArrayAndRepresentationUrl()
+    {
+        $rule = $this->givenARule('ClassDescriptor');
+        $queue = $this->givenAQueue($rule);
+        $queue->shouldReceive('match')->andReturn($rule);
+        $this->renderer->setRouters($queue);
+        $collectionDescriptor = $this->givenACollectionDescriptor('array');
+        $result = $this->renderer->render($collectionDescriptor, 'url');
+
+        $this->assertSame('ClassDescriptor[]', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     */
+    public function testRenderWithFqsenAndRepresentationClassShort()
+    {
+        $rule = $this->givenARule('/classes/My.Namespace.Class.html');
+        $queue = $this->givenAQueue($rule);
+        $queue->shouldReceive('match')->andReturn($rule);
+        $this->renderer->setRouters($queue);
+        $result = $this->renderer->render('\My\Namespace\Class', 'class:short');
+
+        $this->assertSame('<a href="classes/My.Namespace.Class.html">Class</a>', $result);
+    }
+
+    /**
+     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     * @dataProvider provideUrls
+     */
+    public function testRenderWithUrl($url)
+    {
+        $rule = $this->givenARule($url);
+        $queue = $this->givenAQueue($rule);
+        $queue->shouldReceive('match')->andReturn($rule);
+        $this->renderer->setRouters($queue);
+        $result = $this->renderer->render($url, 'url');
+
+        $this->assertSame($url, $result);
+    }
+
+    /**
+     * @return m\MockInterface
+     */
+    protected function givenARule($returnValue)
+    {
+        $rule = m::mock('phpDocumentor\Transformer\Router');
+        $rule->shouldReceive('generate')->andReturn($returnValue);
+        return $rule;
+    }
+
+    /**
+     * @return CollectionDescriptor
+     */
+    protected function givenACollectionDescriptor($name)
+    {
+        $classDescriptor = m::mock('phpDocumentor\Descriptor\ClassDescriptor');
+        $classDescriptor->shouldReceive('getName')->andReturn($name);
+        $collectionDescriptor = new CollectionDescriptor($classDescriptor);
+        $collectionDescriptor->setTypes(['ClassDescriptor']);
+        return $collectionDescriptor;
+    }
+
+    /**
+     * @param $rule
+     * @return m\MockInterface
+     */
+    private function givenAQueue($rule)
+    {
+        $queue = m::mock('phpDocumentor\Transformer\Router\Queue');
+        $router = m::mock('phpDocumentor\Transformer\Router\StandardRouter');
+        $queue->shouldReceive('insert');
+        $router->shouldReceive('match')->andReturn($rule);
+        return $queue;
+    }
+
+    /**
+     * @return array
+     */
+    public function provideUrls()
+    {
+        return [
+            ['http://phpdoc.org'],
+            ['https://phpdoc.org'],
+            ['ftp://phpdoc.org']
+        ];
+    }
+}

--- a/tests/unit/phpDocumentor/Transformer/Router/RendererTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/RendererTest.php
@@ -136,7 +136,6 @@ class RendererTest extends \PHPUnit_Framework_TestCase
         $rule = $this->givenARule('@Class::$property');
         $queue = $this->givenAQueue($rule);
         $queue->shouldReceive('match')->with('@Class::$property')->andReturn($rule);
-        $queue->shouldReceive('match')->with('@')->andReturn($rule);
         $this->renderer->setRouters($queue);
         $result = $this->renderer->convertToRootPath('@Class::$property');
 

--- a/tests/unit/phpDocumentor/Transformer/Router/RendererTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/RendererTest.php
@@ -105,7 +105,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
         $queue = $this->givenAQueue($rule);
         $queue->shouldReceive('match')->andReturn($rule);
         $this->renderer->setRouters($queue);
-        $this->renderer->setDestination('/root/of/project');
+        $this->renderer->setDestination(str_replace('/', DIRECTORY_SEPARATOR,'/root/of/project'));
         $collection = new Collection(['\My\Namespace\Class']);
         $result = $this->renderer->render($collection, 'url');
 

--- a/tests/unit/phpDocumentor/Transformer/Router/RendererTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/RendererTest.php
@@ -19,7 +19,8 @@ use phpDocumentor\Descriptor\Type\CollectionDescriptor;
 /**
  * Test class for phpDocumentor\Transformer\Router\Renderer
  *
- * @covers \phpDocumentor\Transformer\Router\Renderer::<protected>
+ * @coversDefaultClass \phpDocumentor\Transformer\Router\Renderer
+ * @covers ::<protected>
  */
 class RendererTest extends \PHPUnit_Framework_TestCase
 {
@@ -41,8 +42,8 @@ class RendererTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::__construct
-     * @covers \phpDocumentor\Transformer\Router\Renderer::getRouters
+     * @covers ::__construct
+     * @covers ::getRouters
      */
     public function testConstructRenderer()
     {
@@ -52,9 +53,9 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::__construct
-     * @covers \phpDocumentor\Transformer\Router\Renderer::getRouters
-     * @covers \phpDocumentor\Transformer\Router\Renderer::setRouters
+     * @covers ::__construct
+     * @covers ::getRouters
+     * @covers ::setRouters
      */
     public function testGetAndSetRouters()
     {
@@ -81,8 +82,8 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::render
-     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     * @covers ::render
+     * @covers ::convertToRootPath
      */
     public function testRenderWithFqsenAndRepresentationUrl()
     {
@@ -96,8 +97,8 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::render
-     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     * @covers ::render
+     * @covers ::convertToRootPath
      */
     public function testRenderWithCollectionOfFqsensAndRepresentationUrl()
     {
@@ -113,8 +114,8 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::render
-     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     * @covers ::render
+     * @covers ::convertToRootPath
      */
     public function testRenderWithUrlAndNoRuleMatch()
     {
@@ -129,7 +130,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     * @covers ::convertToRootPath
      */
     public function testConvertToRootPathWithUrlAndAtSignInRelativePath()
     {
@@ -143,8 +144,8 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::render
-     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     * @covers ::render
+     * @covers ::convertToRootPath
      */
     public function testRenderWithCollectionDescriptorWithNameIsNotArrayAndRepresentationUrl()
     {
@@ -160,8 +161,8 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::render
-     * @covers \phpDocumentor\Transformer\Router\Renderer::convertToRootPath
+     * @covers ::render
+     * @covers ::convertToRootPath
      */
     public function testRenderWithCollectionDescriptorWithNameIsArrayAndRepresentationUrl()
     {
@@ -176,7 +177,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     * @covers ::render
      */
     public function testRenderWithFqsenAndRepresentationClassShort()
     {
@@ -190,7 +191,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Transformer\Router\Renderer::render
+     * @covers ::render
      * @dataProvider provideUrls
      */
     public function testRenderWithUrl($url)
@@ -205,16 +206,18 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * $param string $returnValue
      * @return m\MockInterface
      */
     protected function givenARule($returnValue)
     {
-        $rule = m::mock('phpDocumentor\Transformer\Router');
+        $rule = m::mock('phpDocumentor\Transformer\Router\Rule');
         $rule->shouldReceive('generate')->andReturn($returnValue);
         return $rule;
     }
 
     /**
+     * @param string $name
      * @return CollectionDescriptor
      */
     protected function givenACollectionDescriptor($name)
@@ -227,7 +230,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param $rule
+     * @param Rule $rule
      * @return m\MockInterface
      */
     private function givenAQueue($rule)


### PR DESCRIPTION
Relative classes that were represented in a namespace alias were treated as ambiguous type and passed on to the Linker for further investigation.
This way they got the wrong namespace, namely the namespace of the container class, and they couldn't be found in the element list.
With this commit a check is added to see if an element is represented by a namespace alias.

Also urls with scheme is ftp:// are left unchanged.

Unit tests are added.
