### PR TITLE
Feature/behat see tests

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -5,4 +5,5 @@ default:
               - phpDocumentor\Behat\Contexts\EnvironmentContext:
                   workingDir: /tmp/phpdoc-behat/core
               - phpDocumentor\Behat\Contexts\Ast\ApiContext
+              - phpDocumentor\Behat\Contexts\Ast\SeeTagContext
             paths:    [ %paths.base%/tests/features/core ]

--- a/tests/features/assets/singlefile/tags/internalSee.php
+++ b/tests/features/assets/singlefile/tags/internalSee.php
@@ -129,7 +129,7 @@ class TestSeeTagIssue
     const CONSTANT = 1;
 
     /**
-     * Class to check if see tags are working correctly
+     * Property to check if see tags are working correctly
      *
      * Inline see to same class relative {@see TestSeeTagIssue}
      * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue}
@@ -192,7 +192,7 @@ class TestSeeTagIssue
     public $property;
 
     /**
-     * Class to check if see tags are working correctly
+     * Method to check if see tags are working correctly
      *
      * Inline see to same class relative {@see TestSeeTagIssue}
      * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue}

--- a/tests/features/assets/singlefile/tags/internalSee.php
+++ b/tests/features/assets/singlefile/tags/internalSee.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace phpDocumentor\Descriptor;
+
+/**
+ * Class to check if see tags are working correctly
+ *
+ * Inline see to same class relative {@see TestSeeTagIssue}
+ * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue}
+ *
+ * Inline see to same class relative {@see \phpDocumentor\Descriptor\TestSeeTagIssue class itself}
+ * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue class itself}
+ *
+ * Inline see to property in same class relative {@see TestSeeTagIssue::$property}
+ * Inline see to property in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::$property}
+ *
+ * Inline see to property in same class relative {@see TestSeeTagIssue::$property own property}
+ * Inline see to property in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::$property own property}
+ *
+ * Inline see to method in same class relative {@see TestSeeTagIssue::method()}
+ * Inline see to method in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::method()}
+ *
+ * Inline see to method in same class relative {@see TestSeeTagIssue::method() own method}
+ * Inline see to method in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::method() own method}
+ *
+ * Inline see to constant in same class relative {@see TestSeeTagIssue::CONSTANT}
+ * Inline see to constant in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT}
+ *
+ * Inline see to constant in same class relative {@see TestSeeTagIssue::CONSTANT own constant}
+ * Inline see to constant in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT own constant}
+ *
+ * @see http://www.phpdoc.org
+ * @see https://www.phpdoc.org
+ * @see http://phpdoc.org
+ * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/uses.html
+ * @see ftp://somesite.nl
+ *
+ * @see TestSeeTagIssue
+ * @see TestSeeTagIssue class itself
+ *
+ * @see \phpDocumentor\Descriptor\TestSeeTagIssue
+ * @see \phpDocumentor\Descriptor\TestSeeTagIssue class itself
+ *
+ * @see TestSeeTagIssue::$property
+ * @see TestSeeTagIssue::$property own property
+ *
+ * @see \phpDocumentor\Descriptor\TestSeeTagIssue::$property
+ * @see \phpDocumentor\Descriptor\TestSeeTagIssue::$property own property
+ *
+ * @see TestSeeTagIssue::method()
+ * @see TestSeeTagIssue::method() own method
+ *
+ * @see \phpDocumentor\Descriptor\TestSeeTagIssue::method()
+ * @see \phpDocumentor\Descriptor\TestSeeTagIssue::method() own method
+ *
+ * @see TestSeeTagIssue::CONSTANT
+ * @see TestSeeTagIssue::CONSTANT own constant
+ *
+ * @see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT
+ * @see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT own constant
+ *
+ * @see CONSTANT
+ * @see $property
+ * @see method()
+ */
+class TestSeeTagIssue
+{
+    /**
+     * Constant to check if see tags are working correctly
+     *
+     * Inline see to same class relative {@see TestSeeTagIssue}
+     * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue}
+     *
+     * Inline see to same class relative {@see \phpDocumentor\Descriptor\TestSeeTagIssue class itself}
+     * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue class itself}
+     *
+     * Inline see to property in same class relative {@see TestSeeTagIssue::$property}
+     * Inline see to property in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::$property}
+     *
+     * Inline see to property in same class relative {@see TestSeeTagIssue::$property own property}
+     * Inline see to property in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::$property own property}
+     *
+     * Inline see to method in same class relative {@see TestSeeTagIssue::method()}
+     * Inline see to method in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::method()}
+     *
+     * Inline see to method in same class relative {@see TestSeeTagIssue::method() own method}
+     * Inline see to method in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::method() own method}
+     *
+     * Inline see to constant in same class relative {@see TestSeeTagIssue::CONSTANT}
+     * Inline see to constant in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT}
+     *
+     * Inline see to constant in same class relative {@see TestSeeTagIssue::CONSTANT own constant}
+     * Inline see to constant in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT own constant}
+     *
+     * @see http://www.phpdoc.org
+     * @see https://www.phpdoc.org
+     * @see http://phpdoc.org
+     * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/uses.html
+     * @see ftp://somesite.nl
+     *
+     * @see TestSeeTagIssue
+     * @see TestSeeTagIssue class itself
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue class itself
+     *
+     * @see TestSeeTagIssue::$property
+     * @see TestSeeTagIssue::$property own property
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::$property
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::$property own property
+     *
+     * @see TestSeeTagIssue::method()
+     * @see TestSeeTagIssue::method() own method
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::method()
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::method() own method
+     *
+     * @see TestSeeTagIssue::CONSTANT
+     * @see TestSeeTagIssue::CONSTANT own constant
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT own constant
+     *
+     * @see CONSTANT
+     * @see $property
+     * @see method()
+     */
+    const CONSTANT = 1;
+
+    /**
+     * Class to check if see tags are working correctly
+     *
+     * Inline see to same class relative {@see TestSeeTagIssue}
+     * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue}
+     *
+     * Inline see to same class relative {@see \phpDocumentor\Descriptor\TestSeeTagIssue class itself}
+     * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue class itself}
+     *
+     * Inline see to property in same class relative {@see TestSeeTagIssue::$property}
+     * Inline see to property in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::$property}
+     *
+     * Inline see to property in same class relative {@see TestSeeTagIssue::$property own property}
+     * Inline see to property in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::$property own property}
+     *
+     * Inline see to method in same class relative {@see TestSeeTagIssue::method()}
+     * Inline see to method in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::method()}
+     *
+     * Inline see to method in same class relative {@see TestSeeTagIssue::method() own method}
+     * Inline see to method in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::method() own method}
+     *
+     * Inline see to constant in same class relative {@see TestSeeTagIssue::CONSTANT}
+     * Inline see to constant in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT}
+     *
+     * Inline see to constant in same class relative {@see TestSeeTagIssue::CONSTANT own constant}
+     * Inline see to constant in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT own constant}
+     *
+     * @see http://www.phpdoc.org
+     * @see https://www.phpdoc.org
+     * @see http://phpdoc.org
+     * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/uses.html
+     * @see ftp://somesite.nl
+     *
+     * @see TestSeeTagIssue
+     * @see TestSeeTagIssue class itself
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue class itself
+     *
+     * @see TestSeeTagIssue::$property
+     * @see TestSeeTagIssue::$property own property
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::$property
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::$property own property
+     *
+     * @see TestSeeTagIssue::method()
+     * @see TestSeeTagIssue::method() own method
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::method()
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::method() own method
+     *
+     * @see TestSeeTagIssue::CONSTANT
+     * @see TestSeeTagIssue::CONSTANT own constant
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT own constant
+     *
+     * @see CONSTANT
+     * @see $property
+     * @see method()
+     */
+    public $property;
+
+    /**
+     * Class to check if see tags are working correctly
+     *
+     * Inline see to same class relative {@see TestSeeTagIssue}
+     * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue}
+     *
+     * Inline see to same class relative {@see \phpDocumentor\Descriptor\TestSeeTagIssue class itself}
+     * Inline see to same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue class itself}
+     *
+     * Inline see to property in same class relative {@see TestSeeTagIssue::$property}
+     * Inline see to property in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::$property}
+     *
+     * Inline see to property in same class relative {@see TestSeeTagIssue::$property own property}
+     * Inline see to property in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::$property own property}
+     *
+     * Inline see to method in same class relative {@see TestSeeTagIssue::method()}
+     * Inline see to method in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::method()}
+     *
+     * Inline see to method in same class relative {@see TestSeeTagIssue::method() own method}
+     * Inline see to method in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::method() own method}
+     *
+     * Inline see to constant in same class relative {@see TestSeeTagIssue::CONSTANT}
+     * Inline see to constant in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT}
+     *
+     * Inline see to constant in same class relative {@see TestSeeTagIssue::CONSTANT own constant}
+     * Inline see to constant in same class absolute {@see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT own constant}
+     *
+     * @see http://www.phpdoc.org
+     * @see https://www.phpdoc.org
+     * @see http://phpdoc.org
+     * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/uses.html
+     * @see ftp://somesite.nl
+     *
+     * @see TestSeeTagIssue
+     * @see TestSeeTagIssue class itself
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue class itself
+     *
+     * @see TestSeeTagIssue::$property
+     * @see TestSeeTagIssue::$property own property
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::$property
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::$property own property
+     *
+     * @see TestSeeTagIssue::method()
+     * @see TestSeeTagIssue::method() own method
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::method()
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::method() own method
+     *
+     * @see TestSeeTagIssue::CONSTANT
+     * @see TestSeeTagIssue::CONSTANT own constant
+     *
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT
+     * @see \phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT own constant
+     *
+     * @see CONSTANT
+     * @see $property
+     * @see method()
+     */
+    public function method()
+    {
+        // body of method
+    }
+}

--- a/tests/features/bootstrap/Ast/BaseContext.php
+++ b/tests/features/bootstrap/Ast/BaseContext.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Behat\Contexts\Ast;
+
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+
+class BaseContext
+{
+    /** @var EnvironmentContext */
+    private $environmentContext;
+
+    /** @BeforeScenario */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        $this->environmentContext = $environment->getContext('phpDocumentor\Behat\Contexts\EnvironmentContext');
+    }
+
+    /**
+     * @param string $classFqsen
+     * @return ClassDescriptor
+     * @throws \Exception
+     */
+    protected function findClassByFqsen($classFqsen)
+    {
+        $ast = $this->getAst();
+        foreach ($ast->getFiles() as $file) {
+            /** @var ClassDescriptor $classDescriptor */
+            foreach ($file->getClasses() as $classDescriptor) {
+                if ($classDescriptor->getFullyQualifiedStructuralElementName() === $classFqsen) {
+                    return $classDescriptor;
+                }
+            }
+        }
+
+        throw new \Exception(sprintf('Didn\'t find expected class "%s"', $classFqsen));
+    }
+
+    /**
+     * @return ProjectDescriptor|null
+     * @throws \Exception when AST file doesn't exist
+     */
+    protected function getAst()
+    {
+        $file = $this->environmentContext->getWorkingDir() . '/ast.dump';
+        if (!file_exists($file)) {
+            throw new \Exception(
+                'The output of phpDocumentor was not generated, this probably means that the execution failed. '
+                . 'The error output was: ' . $this->environmentContext->getErrorOutput()
+            );
+        }
+
+        return unserialize(file_get_contents($file));
+    }
+}

--- a/tests/features/bootstrap/Ast/SeeTagContext.php
+++ b/tests/features/bootstrap/Ast/SeeTagContext.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Behat\Contexts\Ast;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
+use phpDocumentor\Reflection\DocBlock\Type\Collection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * This class contains the context methods for tests of the see tag.
+ */
+final class SeeTagContext extends BaseContext implements Context
+{
+
+
+    /**
+     * @param string $classFqsen
+     * @param $reference
+     * @throws \Exception
+     * @Then class ":classFqsen" has a tag see referencing url ":reference"
+     */
+    public function classHasTagSeeReferencingUrl($classFqsen, $reference)
+    {
+        $class = $this->findClassByFqsen($classFqsen);
+        $seeTags = $class->getTags()->get('see', new Collection());
+        /** @var SeeTag $tag */
+        foreach ($seeTags as $tag) {
+            if ($tag->getReference() === $reference) {
+                return;
+            }
+        }
+
+        throw new \Exception(sprintf('Missing see tag with reference "%s"', $reference));
+    }
+
+    /**
+     * @param string $classFqsen
+     * @param $element
+     * @param $reference
+     * @Then class ":classFqsen" has :number tag/tags see referencing :element descriptor ":reference"
+     */
+    public function classHasTagSeeReferencing($classFqsen, $number, $element, $reference)
+    {
+        $this->classHasTagSeeReferencingWithDescription($classFqsen, $number, $element, $reference, new PyStringNode([],0));
+    }
+
+    /**
+     * @param string $classFqsen
+     * @param $element
+     * @param $reference
+     * @param $description
+     * @throws \Exception
+     * @Then class ":classFqsen" has :number tag/tags see referencing :element descriptor ":reference" with description:
+     */
+    public function classHasTagSeeReferencingWithDescription($classFqsen, $number, $element, $reference, PyStringNode $description)
+    {
+        $count = 0;
+        $class = $this->findClassByFqsen($classFqsen);
+        $seeTags = $class->getTags()->get('see', new Collection());
+        $element = '\\phpDocumentor\\Descriptor\\' .ucfirst($element) . 'Descriptor';
+        /** @var SeeTag $tag */
+        foreach ($seeTags as $tag) {
+            $r = $tag->getReference();
+            if ($r instanceof $element
+                && $r->getFullyQualifiedStructuralElementName() === $reference
+                && $tag->getDescription() === $description->getRaw()
+            ) {
+                $count++;
+            }
+        }
+
+        Assert::assertEquals($number, $count, sprintf('Missing see tag with reference "%s"', $reference));
+    }
+}

--- a/tests/features/core/tags/see class level.feature
+++ b/tests/features/core/tags/see class level.feature
@@ -1,0 +1,52 @@
+Feature:
+  To be able to reference to external information
+  as a developer
+  I want to be able to reference to other elements in the same class
+
+  Background:
+    Given A single file named "test.php" based on "tags/internalSee.php"
+    When I run "phpdoc -f test.php"
+
+  Scenario: class level self linking to external urls (http and https)
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has a tag see referencing url "http://www.phpdoc.org"
+    And class "\phpDocumentor\Descriptor\TestSeeTagIssue" has a tag see referencing url "https://www.phpdoc.org"
+    And class "\phpDocumentor\Descriptor\TestSeeTagIssue" has a tag see referencing url "http://www.phpdoc.org/docs/latest/references/phpdoc/tags/uses.html"
+
+  Scenario: class level self linking to external url (Ftp)
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has a tag see referencing url "ftp://somesite.nl"
+
+  Scenario: class level self reference without description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has 2 tags see referencing class descriptor "\phpDocumentor\Descriptor\TestSeeTagIssue"
+
+  Scenario: class level self reference with description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has 2 tags see referencing class descriptor "\phpDocumentor\Descriptor\TestSeeTagIssue" with description:
+  """
+  class itself
+  """
+
+  Scenario: class level own constant reference without description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has 3 tags see referencing constant descriptor "\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT"
+
+  Scenario: class level own constant reference with description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has 2 tags see referencing constant descriptor "\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT" with description:
+  """
+  own constant
+  """
+
+  Scenario: class level own property reference without description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has 3 tags see referencing property descriptor "\phpDocumentor\Descriptor\TestSeeTagIssue::$property"
+
+  Scenario: class level own property reference with description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has 2 tags see referencing property descriptor "\phpDocumentor\Descriptor\TestSeeTagIssue::$property" with description:
+  """
+  own property
+  """
+
+  Scenario: class level own method reference without description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has 3 tags see referencing method descriptor "\phpDocumentor\Descriptor\TestSeeTagIssue::method()"
+
+  Scenario: class level own method reference with description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has 2 tags see referencing method descriptor "\phpDocumentor\Descriptor\TestSeeTagIssue::method()" with description:
+  """
+  own method
+  """

--- a/tests/features/core/tags/see class level.feature
+++ b/tests/features/core/tags/see class level.feature
@@ -7,12 +7,12 @@ Feature:
     Given A single file named "test.php" based on "tags/internalSee.php"
     When I run "phpdoc -f test.php"
 
-  Scenario: class level self linking to external urls (http and https)
+  Scenario: class level linking to external urls (http and https)
     Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has a tag see referencing url "http://www.phpdoc.org"
     And class "\phpDocumentor\Descriptor\TestSeeTagIssue" has a tag see referencing url "https://www.phpdoc.org"
     And class "\phpDocumentor\Descriptor\TestSeeTagIssue" has a tag see referencing url "http://www.phpdoc.org/docs/latest/references/phpdoc/tags/uses.html"
 
-  Scenario: class level self linking to external url (Ftp)
+  Scenario: class level linking to external url (Ftp)
     Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has a tag see referencing url "ftp://somesite.nl"
 
   Scenario: class level self reference without description

--- a/tests/features/core/tags/see description.feature
+++ b/tests/features/core/tags/see description.feature
@@ -1,0 +1,120 @@
+Feature:
+  To be able to create links in the description to other elements
+  As a developer
+  I want to be able to reference to other elements in the same class.
+
+  Background:
+    Given A single file named "test.php" based on "tags/internalSee.php"
+    When I run "phpdoc -f test.php"
+
+  Scenario: class level description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has description:
+    """
+    Inline see to same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+    Inline see to same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+
+    Inline see to same class relative [class itself](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+    Inline see to same class absolute [class itself](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+
+    Inline see to property in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::$property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+    Inline see to property in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::$property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+
+    Inline see to property in same class relative [own property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+    Inline see to property in same class absolute [own property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+
+    Inline see to method in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::method()](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+    Inline see to method in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::method()](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+
+    Inline see to method in same class relative [own method](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+    Inline see to method in same class absolute [own method](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+
+    Inline see to constant in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    Inline see to constant in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+
+    Inline see to constant in same class relative [own constant](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    Inline see to constant in same class absolute [own constant](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    """
+
+  Scenario: constant level description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has constant CONSTANT with description:
+    """
+    Inline see to same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+    Inline see to same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+
+    Inline see to same class relative [class itself](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+    Inline see to same class absolute [class itself](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+
+    Inline see to property in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::$property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+    Inline see to property in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::$property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+
+    Inline see to property in same class relative [own property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+    Inline see to property in same class absolute [own property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+
+    Inline see to method in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::method()](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+    Inline see to method in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::method()](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+
+    Inline see to method in same class relative [own method](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+    Inline see to method in same class absolute [own method](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+
+    Inline see to constant in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    Inline see to constant in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+
+    Inline see to constant in same class relative [own constant](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    Inline see to constant in same class absolute [own constant](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    """
+
+  Scenario: method level description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has method method with description:
+    """
+    Inline see to same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+    Inline see to same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+
+    Inline see to same class relative [class itself](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+    Inline see to same class absolute [class itself](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+
+    Inline see to property in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::$property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+    Inline see to property in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::$property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+
+    Inline see to property in same class relative [own property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+    Inline see to property in same class absolute [own property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+
+    Inline see to method in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::method()](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+    Inline see to method in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::method()](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+
+    Inline see to method in same class relative [own method](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+    Inline see to method in same class absolute [own method](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+
+    Inline see to constant in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    Inline see to constant in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+
+    Inline see to constant in same class relative [own constant](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    Inline see to constant in same class absolute [own constant](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    """
+
+  Scenario: property level description
+    Then class "\phpDocumentor\Descriptor\TestSeeTagIssue" has property property with description:
+    """
+    Inline see to same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+    Inline see to same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+
+    Inline see to same class relative [class itself](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+    Inline see to same class absolute [class itself](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html)
+
+    Inline see to property in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::$property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+    Inline see to property in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::$property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+
+    Inline see to property in same class relative [own property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+    Inline see to property in same class absolute [own property](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#property_property)
+
+    Inline see to method in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::method()](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+    Inline see to method in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::method()](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+
+    Inline see to method in same class relative [own method](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+    Inline see to method in same class absolute [own method](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#method_method)
+
+    Inline see to constant in same class relative [\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    Inline see to constant in same class absolute [\phpDocumentor\Descriptor\TestSeeTagIssue::CONSTANT](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+
+    Inline see to constant in same class relative [own constant](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    Inline see to constant in same class absolute [own constant](../classes/phpDocumentor.Descriptor.TestSeeTagIssue.html#constant_CONSTANT)
+    """


### PR DESCRIPTION
This covers a number of cases for the usecases applicable to the see tag.
In global all types are covered. But when looking in more detail there are addional
tests required.

This pr is an addition on #1858 and needs to be rebased before merging.
