### PR TITLE
tweaking gitignore to cover windows bin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 .idea
-bin/behat
-bin/phpcs
-bin/phpunit
-bin/jsonlint
-bin/validate-json
+bin/behat*
+bin/phpcs*
+bin/phpunit*
+bin/jsonlint*
+bin/validate-json*
 build.properties
 build/*
 .buildpath


### PR DESCRIPTION
post composer install, we get several .bat files on windows.
```sh
$ git status
On branch develop
Your branch is up-to-date with 'origin/develop'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        bin/behat.bat
        bin/jsonlint.bat
        bin/phpcs.bat
        bin/phpunit.bat
        bin/validate-json.bat
```

this otherwise-pointless patch results in both types of files being safely ignored.
```sh
$ git status
On branch gitignore-windows
nothing to commit, working tree clean
```