### PR TITLE
Issue 920 Make uses show up in templates clean and responsive

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -6,4 +6,5 @@ default:
                   workingDir: /tmp/phpdoc-behat/core
               - phpDocumentor\Behat\Contexts\Ast\ApiContext
               - phpDocumentor\Behat\Contexts\Ast\SeeTagContext
+              - phpDocumentor\Behat\Contexts\Ast\UsesTagContext
             paths:    [ %paths.base%/tests/features/core ]

--- a/build.xml
+++ b/build.xml
@@ -92,7 +92,7 @@
     <!-- Generate behat results -->
     <target name="build:behat" description="Run BDD tests for phpDocumentor">
         <exec executable="php" dir="${project.basedir}" checkreturn="true" passthru="true">
-            <arg line="bin/behat --no-paths -f progress" />
+            <arg line="bin/behat -f progress" />
         </exec>
     </target>
 

--- a/data/templates/clean/class.html.twig
+++ b/data/templates/clean/class.html.twig
@@ -231,13 +231,21 @@
                                 <dd><a href="{{ (tag.reference|route('url')) ?: tag.link }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
                             {% endfor %}
                         {% endfor %}
+                        {% for tagName,tags in node.tags if tagName in ['uses'] %}
+                            {% if loop.first %}
+                                <dt>Uses</dt>
+                            {% endif %}
+                            {% for tag in tags %}
+                                <dd><a href="{{ (tag.reference|route('url')) }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
+                            {% endfor %}
+                        {% endfor %}
 
                         {#<dt>Categories</dt>#}
                             {#<dd><a href="">Assemblers</a></dd>#}
                     </dl>
                     <h2>Tags</h2>
                     <table class="table table-condensed">
-                    {% for tagName,tags in node.tags if tagName not in ['link', 'see', 'abstract', 'example', 'method', 'property', 'property-read', 'property-write', 'package', 'subpackage'] %}
+                    {% for tagName,tags in node.tags if tagName not in ['link', 'see', 'uses', 'abstract', 'example', 'method', 'property', 'property-read', 'property-write', 'package', 'subpackage'] %}
                         <tr>
                             <th>
                                 {{ tagName }}

--- a/data/templates/clean/elements/constant.html.twig
+++ b/data/templates/clean/elements/constant.html.twig
@@ -34,12 +34,12 @@
                         <dd><a href="{{ tag.reference|route('url') ?: tag.link }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
                     {% endfor %}
                 {% endfor %}
-                {% for tagName,tags in method.tags if tagName in ['uses'] %}
+                {% for tagName,tags in constant.tags if tagName in ['uses'] %}
                     {% if loop.first %}
                         <dt>Uses</dt>
                     {% endif %}
                     {% for tag in tags %}
-                        <dd>{{ tag.reference|route|raw }}</dd>
+                        <dd><a href="{{ tag.reference|route('url') }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
                     {% endfor %}
                 {% endfor %}
             </dl>

--- a/data/templates/clean/elements/method.html.twig
+++ b/data/templates/clean/elements/method.html.twig
@@ -94,7 +94,7 @@
                         <dt>Uses</dt>
                     {% endif %}
                     {% for tag in tags %}
-                        <dd>{{ tag.reference|route|raw }}</dd>
+                        <dd><a href="{{ (tag.reference|route('url')) }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
                     {% endfor %}
                 {% endfor %}
             </dl>

--- a/data/templates/clean/elements/property.html.twig
+++ b/data/templates/clean/elements/property.html.twig
@@ -36,12 +36,12 @@
                         <dd><a href="{{ tag.reference|route('url') ?: tag.link }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
                     {% endfor %}
                 {% endfor %}
-                {% for tagName,tags in method.tags if tagName in ['uses'] %}
+                {% for tagName,tags in property.tags if tagName in ['uses'] %}
                     {% if loop.first %}
                         <dt>Uses</dt>
                     {% endif %}
                     {% for tag in tags %}
-                        <dd>{{ tag.reference|route|raw }}</dd>
+                        <dd><a href="{{ tag.reference|route('url') }}"><span class="namespace-wrapper">{{ tag.description ?: tag.reference }}</span></a></dd>
                     {% endfor %}
                 {% endfor %}
             </dl>

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/UsesAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/UsesAssembler.php
@@ -11,9 +11,12 @@
 
 namespace phpDocumentor\Descriptor\Builder\Reflector\Tags;
 
+use phpDocumentor\Compiler\Linker\Linker;
 use phpDocumentor\Descriptor\Builder\Reflector\AssemblerAbstract;
 use phpDocumentor\Descriptor\Tag\UsesDescriptor;
+use phpDocumentor\Reflection\DocBlock\Context;
 use phpDocumentor\Reflection\DocBlock\Tag\UsesTag;
+use phpDocumentor\Reflection\DocBlock\Type\Collection;
 
 class UsesAssembler extends AssemblerAbstract
 {
@@ -28,8 +31,60 @@ class UsesAssembler extends AssemblerAbstract
     {
         $descriptor = new UsesDescriptor($data->getName());
         $descriptor->setDescription($data->getDescription());
-        $descriptor->setReference($data->getReference());
+        $reference = $data->getReference();
+        $context = $data->getDocBlock() ? $data->getDocBlock()->getContext() : null;
+
+        if ($reference !== 'self'
+            && $reference !== '$this'
+            && $reference[0] !== '\\'
+        ) {
+            // Expand FQCN part of the FQSEN
+            $referenceParts = explode('::', $reference);
+
+            if (count($referenceParts) > 1 || $this->referenceIsNamespaceAlias($reference, $context)) {
+                $referenceParts = $this->setFirstReferencePartAsType($context, $referenceParts);
+            } elseif (isset($reference[0])) {
+                array_unshift($referenceParts, Linker::CONTEXT_MARKER);
+            }
+
+            $reference = implode('::', $referenceParts);
+        }
+
+        $descriptor->setReference($reference);
 
         return $descriptor;
+    }
+
+    /**
+     * @param Context $context
+     * @param string[] $referenceParts
+     * @return array The returned array will consist of a Collection object with the type, and strings for methods, etc.
+     */
+    private function setFirstReferencePartAsType($context, $referenceParts)
+    {
+        $type = current($referenceParts);
+        $type = new Collection(
+            array($type),
+            $context
+        );
+        $referenceParts[0] = $type;
+        return $referenceParts;
+    }
+
+    /**
+     * When you have a relative reference to a class, we need to check if this class exists in the namespace aliases
+     *
+     * @param string $reference
+     * @param Context $context
+     * @return bool
+     */
+    private function referenceIsNamespaceAlias($reference, $context)
+    {
+        /** @var \phpDocumentor\Reflection\DocBlock\Context $context*/
+        foreach ($context->getNamespaceAliases() as $alias) {
+            if (substr($alias, -strlen($reference)) === $reference) {
+                return true;
+            }
+        }
     }
 }

--- a/src/phpDocumentor/Transformer/ServiceProvider.php
+++ b/src/phpDocumentor/Transformer/ServiceProvider.php
@@ -97,6 +97,7 @@ class ServiceProvider extends \stdClass implements ServiceProviderInterface
             'phpDocumentor\Descriptor\Tag\ParamDescriptor'       => array('types'),
             'phpDocumentor\Descriptor\Tag\ReturnDescriptor'      => array('types'),
             'phpDocumentor\Descriptor\Tag\SeeDescriptor'         => array('reference'),
+            'phpDocumentor\Descriptor\Tag\UsesDescriptor'        => array('reference'),
             'phpDocumentor\Descriptor\Type\CollectionDescriptor' => array('baseType', 'types', 'keyTypes'),
         );
 
@@ -147,6 +148,7 @@ class ServiceProvider extends \stdClass implements ServiceProviderInterface
                 return new Router\StandardRouter($projectDescriptorBuilder);
             }
         );
+
         $app['transformer.routing.external'] = $app->share(
             function ($container) {
                 return new Router\ExternalRouter($container['config']);

--- a/tests/features/assets/singlefile/tags/internalUses.php
+++ b/tests/features/assets/singlefile/tags/internalUses.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace phpDocumentor\Descriptor;
+
+/**
+ * Class to check if uses tags are working correctly
+ *
+ * @uses TestUsesTagIssue
+ * @uses TestUsesTagIssue class itself
+ *
+ * @uses \phpDocumentor\Descriptor\TestUsesTagIssue
+ * @uses \phpDocumentor\Descriptor\TestUsesTagIssue class itself
+ *
+ * @uses TestUsesTagIssue::$property
+ * @uses TestUsesTagIssue::$property own property
+ *
+ * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::$property
+ * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::$property own property
+ *
+ * @uses TestUsesTagIssue::method()
+ * @uses TestUsesTagIssue::method() own method
+ *
+ * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::method()
+ * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::method() own method
+ *
+ * @uses TestUsesTagIssue::CONSTANT
+ * @uses TestUsesTagIssue::CONSTANT own constant
+ *
+ * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT
+ * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT own constant
+ *
+ * @uses CONSTANT
+ * @uses $property
+ * @uses method()
+ */
+class TestUsesTagIssue
+{
+    /**
+     * Constant to check if uses tags are working correctly
+     *
+     * @uses TestUsesTagIssue
+     * @uses TestUsesTagIssue class itself
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue class itself
+     *
+     * @uses TestUsesTagIssue::$property
+     * @uses TestUsesTagIssue::$property own property
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::$property
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::$property own property
+     *
+     * @uses TestUsesTagIssue::method()
+     * @uses TestUsesTagIssue::method() own method
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::method()
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::method() own method
+     *
+     * @uses TestUsesTagIssue::CONSTANT
+     * @uses TestUsesTagIssue::CONSTANT own constant
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT own constant
+     *
+     * @uses CONSTANT
+     * @uses $property
+     * @uses method()
+     */
+    const CONSTANT = 1;
+
+    /**
+     * Property to check if uses tags are working correctly
+     *
+     * @uses TestUsesTagIssue
+     * @uses TestUsesTagIssue class itself
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue class itself
+     *
+     * @uses TestUsesTagIssue::$property
+     * @uses TestUsesTagIssue::$property own property
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::$property
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::$property own property
+     *
+     * @uses TestUsesTagIssue::method()
+     * @uses TestUsesTagIssue::method() own method
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::method()
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::method() own method
+     *
+     * @uses TestUsesTagIssue::CONSTANT
+     * @uses TestUsesTagIssue::CONSTANT own constant
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT own constant
+     *
+     * @uses CONSTANT
+     * @uses $property
+     * @uses method()
+     */
+    public $property;
+
+    /**
+     * Method to check if uses tags are working correctly
+     *
+     * @uses TestUsesTagIssue
+     * @uses TestUsesTagIssue class itself
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue class itself
+     *
+     * @uses TestUsesTagIssue::$property
+     * @uses TestUsesTagIssue::$property own property
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::$property
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::$property own property
+     *
+     * @uses TestUsesTagIssue::method()
+     * @uses TestUsesTagIssue::method() own method
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::method()
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::method() own method
+     *
+     * @uses TestUsesTagIssue::CONSTANT
+     * @uses TestUsesTagIssue::CONSTANT own constant
+     *
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT
+     * @uses \phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT own constant
+     *
+     * @uses CONSTANT
+     * @uses $property
+     * @uses method()
+     */
+    public function method()
+    {
+        // body of method
+    }
+}

--- a/tests/features/bootstrap/Ast/UsesTagContext.php
+++ b/tests/features/bootstrap/Ast/UsesTagContext.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Behat\Contexts\Ast;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
+use phpDocumentor\Reflection\DocBlock\Type\Collection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * This class contains the context methods for tests of the uses tag.
+ */
+final class UsesTagContext extends BaseContext implements Context
+{
+    /**
+     * @param string $classFqsen
+     * @param $reference
+     * @throws \Exception
+     * @Then class ":classFqsen" has a tag uses referencing url ":reference"
+     */
+    public function classHasTagUsesReferencingUrl($classFqsen, $reference)
+    {
+        $class = $this->findClassByFqsen($classFqsen);
+        $usesTags = $class->getTags()->get('uses', new Collection());
+        /** @var UsesTag $tag */
+        foreach ($usesTags as $tag) {
+            if ($tag->getReference() === $reference) {
+                return;
+            }
+        }
+
+        throw new \Exception(sprintf('Missing uses tag with reference "%s"', $reference));
+    }
+
+    /**
+     * @param string $classFqsen
+     * @param $element
+     * @param $reference
+     * @Then class ":classFqsen" has :number tag/tags uses referencing :element descriptor ":reference"
+     */
+    public function classHasTagUsesReferencing($classFqsen, $number, $element, $reference)
+    {
+        $this->classHasTagUsesReferencingWithDescription($classFqsen, $number, $element, $reference, new PyStringNode([],0));
+    }
+
+    /**
+     * @param string $classFqsen
+     * @param $element
+     * @param $reference
+     * @param $description
+     * @throws \Exception
+     * @Then class ":classFqsen" has :number tag/tags uses referencing :element descriptor ":reference" with description:
+     */
+    public function classHasTagUsesReferencingWithDescription($classFqsen, $number, $element, $reference, PyStringNode $description)
+    {
+        $count = 0;
+        $class = $this->findClassByFqsen($classFqsen);
+        $usesTags = $class->getTags()->get('uses', new Collection());
+        $element = '\\phpDocumentor\\Descriptor\\' .ucfirst($element) . 'Descriptor';
+        /** @var UsesTag $tag */
+        foreach ($usesTags as $tag) {
+            $r = $tag->getReference();
+            if ($r instanceof $element
+                && $r->getFullyQualifiedStructuralElementName() === $reference
+                && $tag->getDescription() === $description->getRaw()
+            ) {
+                $count++;
+            }
+        }
+
+        Assert::assertEquals($number, $count, sprintf('Missing uses tag with reference "%s"', $reference));
+    }
+}

--- a/tests/features/core/tags/uses class level.feature
+++ b/tests/features/core/tags/uses class level.feature
@@ -1,0 +1,44 @@
+Feature:
+  To be able to reference to external information
+  as a developer
+  I want to be able to reference to other elements in the same class
+
+  Background:
+    Given A single file named "test.php" based on "tags/internalUses.php"
+    When I run "phpdoc -f test.php"
+
+  Scenario: class level self reference without description
+    Then class "\phpDocumentor\Descriptor\TestUsesTagIssue" has 2 tags uses referencing class descriptor "\phpDocumentor\Descriptor\TestUsesTagIssue"
+
+  Scenario: class level self reference with description
+    Then class "\phpDocumentor\Descriptor\TestUsesTagIssue" has 2 tags uses referencing class descriptor "\phpDocumentor\Descriptor\TestUsesTagIssue" with description:
+  """
+  class itself
+  """
+
+  Scenario: class level own constant reference without description
+    Then class "\phpDocumentor\Descriptor\TestUsesTagIssue" has 3 tags uses referencing constant descriptor "\phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT"
+
+  Scenario: class level own constant reference with description
+    Then class "\phpDocumentor\Descriptor\TestUsesTagIssue" has 2 tags uses referencing constant descriptor "\phpDocumentor\Descriptor\TestUsesTagIssue::CONSTANT" with description:
+  """
+  own constant
+  """
+
+  Scenario: class level own property reference without description
+    Then class "\phpDocumentor\Descriptor\TestUsesTagIssue" has 3 tags uses referencing property descriptor "\phpDocumentor\Descriptor\TestUsesTagIssue::$property"
+
+  Scenario: class level own property reference with description
+    Then class "\phpDocumentor\Descriptor\TestUsesTagIssue" has 2 tags uses referencing property descriptor "\phpDocumentor\Descriptor\TestUsesTagIssue::$property" with description:
+  """
+  own property
+  """
+
+  Scenario: class level own method reference without description
+    Then class "\phpDocumentor\Descriptor\TestUsesTagIssue" has 3 tags uses referencing method descriptor "\phpDocumentor\Descriptor\TestUsesTagIssue::method()"
+
+  Scenario: class level own method reference with description
+    Then class "\phpDocumentor\Descriptor\TestUsesTagIssue" has 2 tags uses referencing method descriptor "\phpDocumentor\Descriptor\TestUsesTagIssue::method()" with description:
+  """
+  own method
+  """

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/UsesAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/UsesAssemblerTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Descriptor\Builder\Reflector\Tags;
+
+use Mockery as m;
+use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
+
+/**
+ * Test class for phpDocumentor\Descriptor\Builder\Reflector\Tags\UsesAssembler
+ *
+ * @coversDefaultClass \phpDocumentor\Descriptor\Builder\Reflector\Tags\UsesAssembler
+ * @covers ::<private>
+ */
+class UsesAssemblerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var UsesAssembler $fixture */
+    protected $fixture;
+
+    /** @var ProjectDescriptorBuilder|m\MockInterface */
+    protected $builderMock;
+
+    /**
+     * Creates a new fixture to test with.
+     */
+    protected function setUp()
+    {
+        $this->builderMock = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
+        $this->fixture = new UsesAssembler();
+        $this->fixture->setBuilder($this->builderMock);
+    }
+
+    /**
+     * @covers ::create
+     */
+    public function testCreateUsesDescriptorFromUsesTagWhenReferenceIsRelativeClassnameNotInNamespaceAliasses()
+    {
+        // Arrange
+        $name = 'uses';
+        $description = 'a uses tag';
+        $reference = 'ReferenceClass';
+        $context = $this->givenAContext([$reference => '\My\Namespace\Alias\AnotherClass']);
+        $docBlock = $this->givenADocBlock($context);
+
+        $usesTagMock = $this->givenAUsesTag($name, $description, $reference, $docBlock);
+
+        // Act
+        $descriptor = $this->fixture->create($usesTagMock);
+
+        // Assert
+        $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
+        $this->assertSame('@context::' . $reference, $descriptor->getReference());
+        $this->assertSame([], $descriptor->getErrors()->getAll());
+    }
+
+    /**
+     * @covers ::create
+     */
+    public function testCreateUsesDescriptorFromUsesTagWhenReferenceIsRelativeClassnameInNamespaceAliases()
+    {
+        // Arrange
+        $name = 'uses';
+        $description = 'a uses tag';
+        $reference = 'ReferenceClass';
+        $context = $this->givenAContext([$reference => '\My\Namespace\Alias\ReferenceClass']);
+        $docBlock = $this->givenADocBlock($context);
+
+        $usesTagMock = $this->givenAUsesTag($name, $description, $reference, $docBlock);
+
+        // Act
+        $descriptor = $this->fixture->create($usesTagMock);
+
+        // Assert
+        $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
+        $this->assertSame('\\My\\Namespace\Alias\\' . $reference, $descriptor->getReference());
+        $this->assertSame([], $descriptor->getErrors()->getAll());
+    }
+
+    /**
+     * @covers ::create
+     * @dataProvider provideReferences
+     */
+    public function testCreateSeeDescriptorFromSeeTagWhenReferenceIsThisSelfOrAbsolute($reference)
+    {
+        // Arrange
+        $name = 'uses';
+        $description = 'a uses tag';
+        $context = $this->givenAContext([]);
+        $docBlock = $this->givenADocBlock($context);
+
+        $usesTagMock = $this->givenAUsesTag($name, $description, $reference, $docBlock);
+
+        // Act
+        $descriptor = $this->fixture->create($usesTagMock);
+
+        // Assert
+        $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
+        $this->assertSame($reference, $descriptor->getReference());
+        $this->assertSame([], $descriptor->getErrors()->getAll());
+    }
+
+    /**
+     * @covers ::create
+     */
+    public function testCreateUsesDescriptorFromUsesTagWhenReferenceHasMultipleParts()
+    {
+        // Arrange
+        $name = 'uses';
+        $description = 'a uses tag';
+        $reference = 'ReferenceClass::$property';
+        $context = $this->givenAContext(['ReferenceClass' => '\My\Namespace\Alias\ReferenceClass']);
+        $docBlock = $this->givenADocBlock($context);
+
+        $usesTagMock = $this->givenAUsesTag($name, $description, $reference, $docBlock);
+
+        // Act
+        $descriptor = $this->fixture->create($usesTagMock);
+
+        // Assert
+        $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
+        $this->assertSame('\\My\\Namespace\Alias\\' . $reference, $descriptor->getReference());
+        $this->assertSame([], $descriptor->getErrors()->getAll());
+    }
+
+    protected function givenAUsesTag($name, $description, $reference, $docBlock)
+    {
+        $seeTagMock = m::mock('phpDocumentor\Reflection\DocBlock\Tag\UsesTag');
+        $seeTagMock->shouldReceive('getName')->andReturn($name);
+        $seeTagMock->shouldReceive('getDescription')->andReturn($description);
+        $seeTagMock->shouldReceive('getReference')->andReturn($reference);
+        $seeTagMock->shouldReceive('getDocBlock')->andReturn($docBlock);
+
+        return $seeTagMock;
+    }
+
+    protected function givenADocBlock($context)
+    {
+        $docBlockMock = m::mock('phpDocumentor\Reflection\DocBlock');
+        $docBlockMock->shouldReceive('getContext')->andReturn($context);
+
+        return $docBlockMock;
+    }
+
+    protected function givenAContext($aliases)
+    {
+        $context = m::mock('phpDocumentor\Reflection\DocBlock\Context');
+        $context->shouldReceive('getNamespace')->andReturn('\My\Namespace');
+        $context->shouldReceive('getNamespaceAliases')->andReturn($aliases);
+
+        return $context;
+    }
+
+    public function provideReferences()
+    {
+        return [
+            ['$this'],
+            ['self'],
+            ['\My\Namespace\Class']
+        ];
+    }
+}

--- a/tests/unit/phpDocumentor/Transformer/ServiceProviderTest.php
+++ b/tests/unit/phpDocumentor/Transformer/ServiceProviderTest.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer;
+
+use Cilex\Application;
+use \phpDocumentor\Descriptor\ProjectDescriptorBuilder;
+use Mockery as m;
+
+/**
+ * Tests for phpDocumentor\Translator\ServiceProvider
+ * @coversDefaultClass \phpDocumentor\Transformer\ServiceProvider
+ * @covers ::<protected>
+ */
+class ServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ServiceProvider $fixture */
+    protected $fixture = null;
+
+    /** @var \Cilex\Application $application */
+    protected $application = null;
+
+    /** @var ProjectDescriptorBuilder  */
+    protected $projectDescriptorBuilder;
+
+    /**
+     * Setup test fixture and mocks used in this TestCase
+     */
+    protected function setUp()
+    {
+        $this->application = new Application('test');
+        $this->projectDescriptorBuilder = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
+        $this->application['descriptor.builder'] = $this->projectDescriptorBuilder;
+        $this->application['serializer'] = m::mock('JMS\Serializer\Serializer');
+
+        $configuration = new \phpDocumentor\Configuration();
+        $finder = m::mock('\phpDocumentor\Descriptor\Example\Finder');
+        $this->application['config'] = $configuration;
+        $this->application['parser.example.finder'] = $finder;
+
+        $logger = m::mock('\monolog\Logger');
+        $this->application['monolog'] = $logger;
+
+        $analyzer = m::mock('\phpDocumentor\Descriptor\ProjectAnalyzer');
+        $this->application['descriptor.analyzer'] = $analyzer;
+
+        $loggerHelper = m::mock('\phpDocumentor\Command\Helper\LoggerHelper');
+        $loggerHelper->shouldReceive('getName')->andReturn('phpdocumentor_logger');
+        $loggerHelper->shouldReceive('setHelperSet');
+        $loggerHelper->shouldReceive('addOptions');
+        $this->application['console']->getHelperSet()->set($loggerHelper);
+
+        $this->fixture = new ServiceProvider();
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterSetsLinkerSubstitutions()
+    {
+        $this->fixture->register($this->application);
+
+        $substitutions = $this->application['linker.substitutions'];
+        $this->assertSame($substitutions, $this->givenLinkerSubstitutions());
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterSetsCompiler()
+    {
+        $this->fixture->register($this->application);
+
+        $compiler = $this->application->offsetGet('compiler');
+
+        $this->assertInstanceOf('phpDocumentor\Compiler\Compiler', $compiler);
+        $this->assertCount(9, $compiler);
+        $this->assertInstanceOf('phpDocumentor\Compiler\Pass\ElementsIndexBuilder', $compiler->current());
+        $compiler->next();
+        $this->assertInstanceOf('phpDocumentor\Compiler\Linker\Linker', $compiler->current());
+        $compiler->next();
+        $this->assertInstanceOf('phpDocumentor\Compiler\Pass\ResolveInlineLinkAndSeeTags', $compiler->current());
+        $compiler->next();
+        $this->assertInstanceOf('phpDocumentor\Compiler\Pass\ExampleTagsEnricher', $compiler->current());
+        $compiler->next();
+        $this->assertInstanceOf('phpDocumentor\Compiler\Pass\PackageTreeBuilder', $compiler->current());
+        $compiler->next();
+        $this->assertInstanceOf('phpDocumentor\Compiler\Pass\NamespaceTreeBuilder', $compiler->current());
+        $compiler->next();
+        $this->assertInstanceOf('phpDocumentor\Compiler\Pass\MarkerFromTagsExtractor', $compiler->current());
+        $compiler->next();
+        $this->assertInstanceOf('phpDocumentor\Transformer\Transformer', $compiler->current());
+        $compiler->next();
+        $this->assertInstanceOf('phpDocumentor\Compiler\Pass\Debug', $compiler->current());
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterSetsLinker()
+    {
+        $this->fixture->register($this->application);
+
+        $linker = $this->application->offsetGet('linker');
+
+        $this->assertInstanceOf('phpDocumentor\Compiler\Linker\Linker', $linker);
+        $this->assertSame($this->givenLinkerSubstitutions(), $linker->getSubstitutions());
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTransformerBehaviourCollection()
+    {
+        $this->fixture->register($this->application);
+
+        $collection = $this->application->offsetGet('transformer.behaviour.collection');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Behaviour\Collection', $collection);
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTransformerRoutingStandard()
+    {
+        $this->fixture->register($this->application);
+
+        $router = $this->application->offsetGet('transformer.routing.standard');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Router\StandardRouter', $router);
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTransformerRoutingExternal()
+    {
+        $this->fixture->register($this->application);
+
+        $router = $this->application->offsetGet('transformer.routing.external');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Router\ExternalRouter', $router);
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTransformerRoutingQueue()
+    {
+        $this->fixture->register($this->application);
+
+        $queue = $this->application->offsetGet('transformer.routing.queue');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Router\Queue', $queue);
+        $this->assertSame($this->application->offsetGet('transformer.routing.external'), $queue->current());
+        $queue->next();
+        $this->assertSame($this->application->offsetGet('transformer.routing.standard'), $queue->current());
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTransformerWriterCollection()
+    {
+        $this->fixture->register($this->application);
+
+        $collection = $this->application->offsetGet('transformer.writer.collection');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Writer\Collection', $collection);
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTemplateLocation()
+    {
+        $this->fixture->register($this->application);
+
+        $location = $this->application->offsetGet('transformer.template.location');
+
+        $this->assertSame('templates', substr($location, -9));
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTemplatePathResolver()
+    {
+        $this->fixture->register($this->application);
+
+        $resolver = $this->application->offsetGet('transformer.template.path_resolver');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Template\PathResolver', $resolver);
+        $this->assertSame('templates', substr($resolver->getTemplatePath(), -9));
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTemplateFactory()
+    {
+        $this->fixture->register($this->application);
+
+        $factory = $this->application->offsetGet('transformer.template.factory');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Template\Factory', $factory);
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTemplateCollection()
+    {
+        $this->fixture->register($this->application);
+
+        $collection = $this->application->offsetGet('transformer.template.collection');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Template\Collection', $collection);
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTransformer()
+    {
+        $this->fixture->register($this->application);
+
+        $transformer = $this->application->offsetGet('transformer');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Transformer', $transformer);
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterTransformCommand()
+    {
+        $this->fixture->register($this->application);
+
+        $transformCommand = $this->application->offsetGet('console')->get('transform');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Command\Project\TransformCommand', $transformCommand);
+    }
+
+    /**
+     * @covers ::register
+     */
+    public function testRegisterListCommand()
+    {
+        $this->fixture->register($this->application);
+
+        $listCommand = $this->application->offsetGet('console')->get('template:list');
+
+        $this->assertInstanceOf('phpDocumentor\Transformer\Command\Template\ListCommand', $listCommand);
+    }
+
+    /**
+     * @covers ::register
+     * @expectedException \phpDocumentor\Transformer\Exception\MissingDependencyException
+     * @expectedExceptionMessage The builder object that is used to construct the ProjectDescriptor is missing
+     */
+    public function testRegisterThrowsExceptionIfBuilderIsMissing()
+    {
+        $this->fixture->register(new Application('test'));
+    }
+
+    /**
+     * @covers ::register
+     * @expectedException \phpDocumentor\Transformer\Exception\MissingDependencyException
+     * @expectedExceptionMessage The serializer object that is used to read the template configuration with is missing
+     */
+    public function testRegisterThrowsExceptionIfSerializerIsMissing()
+    {
+        $application = new Application('test');
+        $projectDescriptorBuilder = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
+        $application['descriptor.builder'] = $projectDescriptorBuilder;
+
+        $this->fixture->register($application);
+    }
+
+    private function givenLinkerSubstitutions()
+    {
+        $substitutions = array(
+            'phpDocumentor\Descriptor\ProjectDescriptor'      => array('files'),
+            'phpDocumentor\Descriptor\FileDescriptor'         => array(
+                'tags',
+                'classes',
+                'interfaces',
+                'traits',
+                'functions',
+                'constants'
+            ),
+            'phpDocumentor\Descriptor\ClassDescriptor'        => array(
+                'tags',
+                'parent',
+                'interfaces',
+                'constants',
+                'properties',
+                'methods',
+                'usedTraits',
+            ),
+            'phpDocumentor\Descriptor\InterfaceDescriptor'       => array(
+                'tags',
+                'parent',
+                'constants',
+                'methods',
+            ),
+            'phpDocumentor\Descriptor\TraitDescriptor'           => array(
+                'tags',
+                'properties',
+                'methods',
+                'usedTraits',
+            ),
+            'phpDocumentor\Descriptor\FunctionDescriptor'        => array('tags', 'arguments'),
+            'phpDocumentor\Descriptor\MethodDescriptor'          => array('tags', 'arguments'),
+            'phpDocumentor\Descriptor\ArgumentDescriptor'        => array('types'),
+            'phpDocumentor\Descriptor\PropertyDescriptor'        => array('tags', 'types'),
+            'phpDocumentor\Descriptor\ConstantDescriptor'        => array('tags', 'types'),
+            'phpDocumentor\Descriptor\Tag\ParamDescriptor'       => array('types'),
+            'phpDocumentor\Descriptor\Tag\ReturnDescriptor'      => array('types'),
+            'phpDocumentor\Descriptor\Tag\SeeDescriptor'         => array('reference'),
+            'phpDocumentor\Descriptor\Tag\UsesDescriptor'        => array('reference'),
+            'phpDocumentor\Descriptor\Type\CollectionDescriptor' => array('baseType', 'types', 'keyTypes'),
+        );
+
+        return $substitutions;
+    }
+}

--- a/tests/unit/phpDocumentor/Transformer/ServiceProviderTest.php
+++ b/tests/unit/phpDocumentor/Transformer/ServiceProviderTest.php
@@ -29,34 +29,37 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     /** @var \Cilex\Application $application */
     protected $application = null;
 
-    /** @var ProjectDescriptorBuilder  */
-    protected $projectDescriptorBuilder;
-
     /**
      * Setup test fixture and mocks used in this TestCase
      */
     protected function setUp()
     {
         $this->application = new Application('test');
-        $this->projectDescriptorBuilder = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
-        $this->application['descriptor.builder'] = $this->projectDescriptorBuilder;
-        $this->application['serializer'] = m::mock('JMS\Serializer\Serializer');
 
-        $configuration = new \phpDocumentor\Configuration();
+        $projectDescriptorBuilder = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
+        $serializer = m::mock('JMS\Serializer\Serializer');
+
+        $transformer = m::mock('phpDocumentor\Transformer\Transformer');
+        $transformer->shouldReceive('getExternalClassDocumentation')->andReturn([]);
+
+        $configuration = m::mock('\phpDocumentor\Configuration');
+        $configuration->shouldReceive('getTransformer')->andReturn($transformer);
+
         $finder = m::mock('\phpDocumentor\Descriptor\Example\Finder');
-        $this->application['config'] = $configuration;
-        $this->application['parser.example.finder'] = $finder;
-
         $logger = m::mock('\monolog\Logger');
-        $this->application['monolog'] = $logger;
-
         $analyzer = m::mock('\phpDocumentor\Descriptor\ProjectAnalyzer');
-        $this->application['descriptor.analyzer'] = $analyzer;
 
         $loggerHelper = m::mock('\phpDocumentor\Command\Helper\LoggerHelper');
         $loggerHelper->shouldReceive('getName')->andReturn('phpdocumentor_logger');
         $loggerHelper->shouldReceive('setHelperSet');
         $loggerHelper->shouldReceive('addOptions');
+
+        $this->application['descriptor.builder'] = $projectDescriptorBuilder;
+        $this->application['serializer'] = $serializer;
+        $this->application['config'] = $configuration;
+        $this->application['parser.example.finder'] = $finder;
+        $this->application['monolog'] = $logger;
+        $this->application['descriptor.analyzer'] = $analyzer;
         $this->application['console']->getHelperSet()->set($loggerHelper);
 
         $this->fixture = new ServiceProvider();


### PR DESCRIPTION
With this PR the @uses tags show up in the clean and responsive templates. 
The @throws tags and the @used-by tags have not yet been fixed.

A behat scenario is included to test the correct working for tags referring to the same file. However, it has been manually tested that referrals to other files also work.