### PR TITLE
Adds test to confirm correct parsing of const

### DIFF
--- a/tests/features/assets/singlefile/syntax/constarray.php
+++ b/tests/features/assets/singlefile/syntax/constarray.php
@@ -1,0 +1,8 @@
+<?php
+
+class A {
+    const CONFIG_CONFASSISTANT = [
+        'test',
+        'test2'
+    ];
+}

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -19,6 +19,7 @@ use phpDocumentor\Behat\Contexts\EnvironmentContext;
 use phpDocumentor\Descriptor\ArgumentDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\ConstantDescriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\MethodDescriptor;
@@ -206,6 +207,19 @@ class ApiContext extends BaseContext implements Context
 
         //TODO: enable this check when we support variadic arguments.
         //Assert::assertTrue($argumentD->isVariadic(), 'Expected argument to be variadic');
+    }
+
+    /**
+     * @param string $classFqsen
+     * @param string $constantName
+     * @Then class ":classFqsen" has a constant :constantName
+     */
+    public function classHasConstant($classFqsen, $constantName)
+    {
+        /** @var ClassDescriptor $class */
+        $class = $this->findClassByFqsen($classFqsen);
+        $constant = $class->getConstants()->get($constantName);
+        Assert::assertInstanceOf(ConstantDescriptor::class, $constant);
     }
 
     /**

--- a/tests/features/core/syntax/constarray.feature
+++ b/tests/features/core/syntax/constarray.feature
@@ -1,0 +1,9 @@
+Feature: Phpdocumentor is able to process varidict parameters
+
+  @php7.0+
+  Scenario:
+    Given A single file named "test.php" based on "syntax/constarray.php"
+    When I run "phpdoc -f test.php"
+    Then the application must have run successfully
+    And the AST has a class named "A" in file "test.php"
+    And class "\A" has a constant "CONFIG_CONFASSISTANT"


### PR DESCRIPTION
With the upgrade to new reflection components this should work out
of the box. This test confirms that we are able to parse this syntax

Fixes #1883