### PR TITLE
Feature/1828 grouped namespaces

### DIFF
--- a/tests/features/assets/singlefile/syntax/constarray.php
+++ b/tests/features/assets/singlefile/syntax/constarray.php
@@ -1,0 +1,8 @@
+<?php
+
+class A {
+    const CONFIG_CONFASSISTANT = [
+        'test',
+        'test2'
+    ];
+}

--- a/tests/features/assets/singlefile/syntax/groupedUse.php
+++ b/tests/features/assets/singlefile/syntax/groupedUse.php
@@ -1,0 +1,20 @@
+<?php
+namespace phpDocumentor;
+
+use phpDocumentor\{ClassA, ClassB, ClassC as C};
+
+class A {
+
+    /**
+     * @param \phpDocumentor\ClassA $a
+     * @param \phpDocumentor\ClassB $b
+     * @param ClassC $c
+     */
+    public function someMethodWithDocblock(ClassA $a, ClassB $b, C $c) {
+
+    }
+
+    public function someMethodWithoutDocblock(ClassA $a, ClassB $b, C $c) {
+
+    }
+}

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -24,6 +24,7 @@ use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\MethodDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\Tag\ParamDescriptor;
 use phpDocumentor\Descriptor\Tag\VersionDescriptor;
 use phpDocumentor\Reflection\DocBlock\Tag\SeeTag;
 use PHPUnit\Framework\Assert;
@@ -207,6 +208,45 @@ class ApiContext extends BaseContext implements Context
 
         //TODO: enable this check when we support variadic arguments.
         //Assert::assertTrue($argumentD->isVariadic(), 'Expected argument to be variadic');
+    }
+
+    /**
+     * @param string $classFqsen
+     * @param string $methodName
+     * @param string $argument
+     * @param string $type
+     * @Then class ":classFqsen" has a method :method with argument :argument of type ":type"
+     */
+    public function classHasMethodWithAgumentOfType($classFqsen, $methodName, $argument, $type)
+    {
+        $class = $this->findClassByFqsen($classFqsen);
+        /** @var MethodDescriptor $method */
+        $method = $class->getMethods()->get($methodName);
+        Assert::assertArrayHasKey($argument, $method->getArguments());
+        /** @var ArgumentDescriptor $argumentDescriptor */
+        $argumentDescriptor = $method->getArguments()[$argument];
+
+        Assert::assertEquals($type, (string)$argumentDescriptor->getTypes());
+    }
+
+    /**
+     * @param string $classFqsen
+     * @param string $methodName
+     * @param string $param
+     * @param string $type
+     * @Then class ":classFqsen" has a method :method with param :param of type ":type"
+     */
+    public function classHasMethodWithParamOfType($classFqsen, $methodName, $param, $type)
+    {
+        $class = $this->findClassByFqsen($classFqsen);
+        /** @var MethodDescriptor $method */
+        $method = $class->getMethods()->get($methodName);
+        /** @var ParamDescriptor $paramDescriptor */
+        foreach ($method->getParam() as $paramDescriptor) {
+            if($paramDescriptor->getName() === $param) {
+                Assert::assertEquals($type, (string)$paramDescriptor->getTypes());
+            }
+        }
     }
 
     /**

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -19,6 +19,7 @@ use phpDocumentor\Behat\Contexts\EnvironmentContext;
 use phpDocumentor\Descriptor\ArgumentDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\ConstantDescriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\MethodDescriptor;
@@ -206,6 +207,19 @@ class ApiContext extends BaseContext implements Context
 
         //TODO: enable this check when we support variadic arguments.
         //Assert::assertTrue($argumentD->isVariadic(), 'Expected argument to be variadic');
+    }
+
+    /**
+     * @param string $classFqsen
+     * @param string $constantName
+     * @Then class ":classFqsen" has a constant :constantName
+     */
+    public function classHasConstant($classFqsen, $constantName)
+    {
+        /** @var ClassDescriptor $class */
+        $class = $this->findClassByFqsen($classFqsen);
+        $constant = $class->getConstants()->get($constantName);
+        Assert::assertInstanceOf(ConstantDescriptor::class, $constant);
     }
 
     /**

--- a/tests/features/core/syntax/constarray.feature
+++ b/tests/features/core/syntax/constarray.feature
@@ -1,0 +1,9 @@
+Feature: Phpdocumentor is able to process varidict parameters
+
+  @php7.0+
+  Scenario:
+    Given A single file named "test.php" based on "syntax/constarray.php"
+    When I run "phpdoc -f test.php"
+    Then the application must have run successfully
+    And the AST has a class named "A" in file "test.php"
+    And class "\A" has a constant "CONFIG_CONFASSISTANT"

--- a/tests/features/core/syntax/constarray.feature
+++ b/tests/features/core/syntax/constarray.feature
@@ -1,9 +1,0 @@
-Feature: Phpdocumentor is able to process varidict parameters
-
-  @php7.0+
-  Scenario:
-    Given A single file named "test.php" based on "syntax/constarray.php"
-    When I run "phpdoc -f test.php"
-    Then the application must have run successfully
-    And the AST has a class named "A" in file "test.php"
-    And class "\A" has a constant "CONFIG_CONFASSISTANT"

--- a/tests/features/core/syntax/php7.feature
+++ b/tests/features/core/syntax/php7.feature
@@ -1,0 +1,18 @@
+Feature: Phpdocumentor is able to process php 7+ syntax
+
+  @php7.0+
+  Scenario: phpdocumentor is able to process array contants
+    Given A single file named "test.php" based on "syntax/constarray.php"
+    When I run "phpdoc -f test.php"
+    Then the application must have run successfully
+    And the AST has a class named "A" in file "test.php"
+    And class "\A" has a constant "CONFIG_CONFASSISTANT"
+
+  @php7.0+
+  Scenario: phpdocumentor is able to process grouped use and resolves the types correctly
+    Given A single file named "test.php" based on "syntax/groupedUse.php"
+    When I run "phpdoc -f test.php"
+    Then the application must have run successfully
+    And the AST has a class named "A" in file "test.php"
+    And class "\phpDocumentor\A" has a method someMethodWithDocblock with argument a of type "\phpDocumentor\ClassA"
+    And class "\phpDocumentor\A" has a method someMethodWithDocblock with param a of type "\phpDocumentor\ClassA"


### PR DESCRIPTION
From php 7 php supports grouped namespaces. These test confirm
that phpdocumentor supports this syntaxt.