### PR TITLE
Make sure Fqsen's and Url's are handled correctly in StandardRouter

### DIFF
--- a/src/phpDocumentor/Transformer/Router/StandardRouter.php
+++ b/src/phpDocumentor/Transformer/Router/StandardRouter.php
@@ -22,6 +22,8 @@ use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use phpDocumentor\Descriptor\PropertyDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen;
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Url;
 
 /**
  * The default router for phpDocumentor.
@@ -60,6 +62,7 @@ class StandardRouter extends RouterAbstract
         $constantGenerator  = new UrlGenerator\Standard\ConstantDescriptor();
         $functionGenerator  = new UrlGenerator\Standard\FunctionDescriptor();
         $propertyGenerator  = new UrlGenerator\Standard\PropertyDescriptor();
+        $fqsenGenerator     = new UrlGenerator\Standard\FqsenDescriptor();
 
         // Here we cheat! If a string element is passed to this rule then we try to transform it into a Descriptor
         // if the node is translated we do not let it match and instead fall through to one of the other rules.
@@ -83,14 +86,15 @@ class StandardRouter extends RouterAbstract
         $this[] = new Rule(function ($node) { return ($node instanceof ConstantDescriptor); }, $constantGenerator);
         $this[] = new Rule(function ($node) { return ($node instanceof MethodDescriptor); }, $methodGenerator);
         $this[] = new Rule(function ($node) { return ($node instanceof FunctionDescriptor); }, $functionGenerator);
-        $this[] = new Rule( function ($node) { return ($node instanceof PropertyDescriptor); }, $propertyGenerator);
+        $this[] = new Rule(function ($node) { return ($node instanceof PropertyDescriptor); }, $propertyGenerator);
+        $this[] = new Rule(function ($node) { return ($node instanceof Fqsen); }, $fqsenGenerator);
 
         // if this is a link to an external page; return that URL
         $this[] = new Rule(
             function ($node) {
-                return is_string($node) && (substr($node, 0, 7) == 'http://' || substr($node, 0, 8) == 'https://' || substr($node, 0, 6) == 'ftp://');
+                return $node instanceof Url;
             },
-            function ($node) { return $node; }
+            function ($node) { return (string)$node; }
         );
 
         // do not generate a file for every unknown type

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/FqsenDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/FqsenDescriptor.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @copyright 2010-2014 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
+
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen;
+use phpDocumentor\Transformer\Router\UrlGenerator\UrlGeneratorInterface;
+
+/**
+ * Generates a relative URL with properties for use in the generated HTML documentation.
+ */
+class FqsenDescriptor implements UrlGeneratorInterface
+{
+    /**
+     * Generates a URL from the given node or returns false if unable.
+     *
+     * @param string|Fqsen $node
+     *
+     * @return string|false
+     */
+    public function __invoke($node)
+    {
+        if (!($node instanceof Fqsen)) {
+            return false;
+        }
+
+        $converter = new QualifiedNameToUrlConverter();
+        $fqsenParts = explode('::', (string)$node);
+
+        $className = $fqsenParts[0];
+
+        if (count($fqsenParts) === 1) {
+            return '/classes/' . $converter->fromClass($className) . '.html';
+        }
+
+        if (strpos($fqsenParts[1], '$') !== false) {
+            $propertyName = explode('$', $fqsenParts[1]);
+            return '/classes/' . $converter->fromClass($className) . '.html#property_' . $propertyName[1];
+        }
+
+        if (strpos($fqsenParts[1], '()') !== false) {
+            $methodName = explode('()', $fqsenParts[1]);
+            return '/classes/' . $converter->fromClass($className) . '.html#method_' . $methodName[0];
+        }
+
+        return '/classes/' . $converter->fromClass($className) . '.html#constant_' . $fqsenParts[1];
+    }
+}

--- a/tests/unit/phpDocumentor/Transformer/Router/StandardRouterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/StandardRouterTest.php
@@ -13,6 +13,9 @@ namespace phpDocumentor\Transformer\Router;
 
 use Mockery as m;
 use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen;
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Url;
+use phpDocumentor\Reflection\Fqsen as RealFqsen;
 
 class StandardRouterTest extends \PHPUnit_Framework_TestCase
 {
@@ -61,6 +64,51 @@ class StandardRouterTest extends \PHPUnit_Framework_TestCase
             'generator',
             $rule
         );
+    }
+
+    /**
+     * @covers phpDocumentor\Transformer\Router\StandardRouter::configure
+     * @covers phpDocumentor\Transformer\Router\RouterAbstract::__construct
+     * @covers phpDocumentor\Transformer\Router\RouterAbstract::configure
+     * @covers phpDocumentor\Transformer\Router\RouterAbstract::match
+     */
+    public function testIfARouteForAFqsenFileCanBeGenerated()
+    {
+        // Arrange
+        $fqsen = new RealFqsen('\Fqsen');
+        $file = new Fqsen($fqsen);
+
+        // Act
+        $rule = $this->fixture->match($file);
+
+        // Assert
+        $this->assertInstanceOf('phpDocumentor\\Transformer\\Router\\Rule', $rule);
+        $this->assertAttributeInstanceOf(
+            '\phpDocumentor\\Transformer\\Router\\UrlGenerator\\Standard\\FqsenDescriptor',
+            'generator',
+            $rule
+        );
+    }
+
+
+    /**
+     * @covers phpDocumentor\Transformer\Router\StandardRouter::configure
+     * @covers phpDocumentor\Transformer\Router\RouterAbstract::__construct
+     * @covers phpDocumentor\Transformer\Router\RouterAbstract::configure
+     * @covers phpDocumentor\Transformer\Router\RouterAbstract::match
+     */
+    public function testIfARouteForAUrlCanBeGenerated()
+    {
+        // Arrange
+        $file = new Url('http://www.phpdoc.org');
+
+        // Act
+        $rule = $this->fixture->match($file);
+        $result = $rule->generate($file);
+
+        // Assert
+        $this->assertInstanceOf('phpDocumentor\\Transformer\\Router\\Rule', $rule);
+        $this->assertSame('http://www.phpdoc.org', $result);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Transformer/Router/UrlGenerator/Standard/FqsenDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/UrlGenerator/Standard/FqsenDescriptorTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @copyright 2010-2014 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
+
+use Mockery as m;
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen;
+use phpDocumentor\Reflection\Fqsen as RealFqsen;
+
+/**
+ * Test for the MethodDescriptor URL Generator with the Standard Router
+ */
+class FqsenDescriptorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers phpDocumentor\Transformer\Router\UrlGenerator\Standard\FqsenDescriptor::__invoke
+     * @covers phpDocumentor\Transformer\Router\UrlGenerator\Standard\QualifiedNameToUrlConverter::fromClass
+     * @dataProvider provideFqsens
+     */
+    public function testGenerateUrlForFqsenDescriptor($fromFqsen, $toPath)
+    {
+        // Arrange
+        $realFqsen = new RealFqsen($fromFqsen);
+        $fqsen = new Fqsen($realFqsen);
+        $fixture = new FqsenDescriptor();
+
+        // Act
+        $result = $fixture($fqsen);
+
+        // Assert
+        $this->assertSame($toPath, $result);
+    }
+
+    /**
+     * @covers phpDocumentor\Transformer\Router\UrlGenerator\Standard\FqsenDescriptor::__invoke
+     */
+    public function testFqsenDescriptorReturnsFalseWhenNodeOfWrongType()
+    {
+        // Arrange
+        $fqsen = m::mock('phpDocumentor\Reflection\DocBlock\Tags\Reference\Reference');
+        $fixture = new FqsenDescriptor();
+
+        // Act
+        $result = $fixture($fqsen);
+
+        // Assert
+        $this->assertSame(false, $result);
+    }
+
+    public function provideFqsens()
+    {
+        return array(
+            array('\\My\\Space\\Class', '/classes/My.Space.Class.html'),
+            array('\\My\\Space\\Class::$property', '/classes/My.Space.Class.html#property_property'),
+            array('\\My\\Space\\Class::method()', '/classes/My.Space.Class.html#method_method'),
+            array('\\My\\Space\\Class::CONSTANT', '/classes/My.Space.Class.html#constant_CONSTANT'),
+        );
+    }
+}


### PR DESCRIPTION
Due to refactoring the reference in the see tags now points to an fqsen object instead of a descriptor. These could not be handled yet in the StandardRouter which caused the urls to go wrong in the output.

Regular @see tags work again, except for tags pointing to methods and properties (and probably constants) in a class that is in a namespace alias. It doesn't have the correct namespace in the fqsen currently. I will make a separate task for that.