### PR TITLE
Updates Cilex to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.0",
 
-        "cilex/cilex":        "~1.0",
+        "cilex/cilex":        "^2.0",
         "symfony/validator":  "~2.2",
         "symfony/console":    "~2.3",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,47 +4,46 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0816cd5f07e531ae59df781afe8ccd1d",
+    "content-hash": "3a0b6c835862564bb591f7781eb346de",
     "packages": [
         {
             "name": "cilex/cilex",
-            "version": "1.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Cilex/Cilex.git",
-                "reference": "7acd965a609a56d0345e8b6071c261fbdb926cb5"
+                "reference": "c5612545cceac9fadc6ad6dcf6ba28fb0c80c460"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Cilex/Cilex/zipball/7acd965a609a56d0345e8b6071c261fbdb926cb5",
-                "reference": "7acd965a609a56d0345e8b6071c261fbdb926cb5",
+                "url": "https://api.github.com/repos/Cilex/Cilex/zipball/c5612545cceac9fadc6ad6dcf6ba28fb0c80c460",
+                "reference": "c5612545cceac9fadc6ad6dcf6ba28fb0c80c460",
                 "shasum": ""
             },
             "require": {
-                "cilex/console-service-provider": "1.*",
-                "php": ">=5.3.3",
-                "pimple/pimple": "~1.0",
-                "symfony/finder": "~2.1",
-                "symfony/process": "~2.1"
+                "php": ">=5.5.9",
+                "pimple/pimple": "^3.0",
+                "silex/api": "^2.0",
+                "symfony/console": "^2.7 || ^3.0",
+                "symfony/event-dispatcher": "^2.7 || ^3.0",
+                "symfony/process": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*",
-                "symfony/validator": "~2.1"
+                "phpunit/phpunit": "~3.7"
             },
             "suggest": {
-                "monolog/monolog": ">=1.0.0",
-                "symfony/validator": ">=1.0.0",
-                "symfony/yaml": ">=1.0.0"
+                "symfony/validator": "^2.7 || ^3.0",
+                "symfony/yaml": "^2.7 || ^3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-develop": "2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Cilex": "src/"
+                "psr-4": {
+                    "Cilex\\": "src/Cilex"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -54,7 +53,7 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
             "description": "The PHP micro-framework for Command line tools based on the Symfony2 Components",
@@ -63,66 +62,7 @@
                 "cli",
                 "microframework"
             ],
-            "time": "2014-03-29T14:03:13+00:00"
-        },
-        {
-            "name": "cilex/console-service-provider",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Cilex/console-service-provider.git",
-                "reference": "25ee3d1875243d38e1a3448ff94bdf944f70d24e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Cilex/console-service-provider/zipball/25ee3d1875243d38e1a3448ff94bdf944f70d24e",
-                "reference": "25ee3d1875243d38e1a3448ff94bdf944f70d24e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "pimple/pimple": "1.*@dev",
-                "symfony/console": "~2.1"
-            },
-            "require-dev": {
-                "cilex/cilex": "1.*@dev",
-                "silex/silex": "1.*@dev"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Cilex\\Provider\\Console": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Beau Simensen",
-                    "email": "beau@dflydev.com",
-                    "homepage": "http://beausimensen.com"
-                },
-                {
-                    "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
-                }
-            ],
-            "description": "Console Service Provider",
-            "keywords": [
-                "cilex",
-                "console",
-                "pimple",
-                "service-provider",
-                "silex"
-            ],
-            "time": "2012-12-19T10:50:58+00:00"
+            "time": "2016-11-20T14:31:12+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -1160,30 +1100,34 @@
         },
         {
             "name": "pimple/pimple",
-            "version": "v1.1.1",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silexphp/Pimple.git",
-                "reference": "2019c145fe393923f3441b23f29bbdfaa5c58c4d"
+                "reference": "4d45fb62d96418396ec58ba76e6f065bca16e10a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/2019c145fe393923f3441b23f29bbdfaa5c58c4d",
-                "reference": "2019c145fe393923f3441b23f29bbdfaa5c58c4d",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/4d45fb62d96418396ec58ba76e6f065bca16e10a",
+                "reference": "4d45fb62d96418396ec58ba76e6f065bca16e10a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.3.0",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
-                    "Pimple": "lib/"
+                    "Pimple": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1196,13 +1140,13 @@
                     "email": "fabien@symfony.com"
                 }
             ],
-            "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
+            "description": "Pimple, a simple Dependency Injection Container",
             "homepage": "http://pimple.sensiolabs.org",
             "keywords": [
                 "container",
                 "dependency injection"
             ],
-            "time": "2013-11-22T08:30:29+00:00"
+            "time": "2017-07-23T07:32:15+00:00"
         },
         {
             "name": "psr/cache",
@@ -1345,6 +1289,60 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "silex/api",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/silexphp/Silex-Api.git",
+                "reference": "69617ecf52581bbd6b315424f45b40783189e902"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/silexphp/Silex-Api/zipball/69617ecf52581bbd6b315424f45b40783189e902",
+                "reference": "69617ecf52581bbd6b315424f45b40783189e902",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "pimple/pimple": "~3.0"
+            },
+            "suggest": {
+                "silex/silex": "For BootableProviderInterface and ControllerProviderInterface",
+                "symfony/event-dispatcher": "For EventListenerProviderInterface"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Silex\\Api\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "The Silex interfaces",
+            "homepage": "http://silex.sensiolabs.org",
+            "keywords": [
+                "microframework"
+            ],
+            "time": "2017-07-23T07:40:14+00:00"
         },
         {
             "name": "symfony/config",
@@ -4696,7 +4694,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=7.0"
     },
     "platform-dev": []
 }

--- a/src/Cilex/Provider/MonologServiceProvider.php
+++ b/src/Cilex/Provider/MonologServiceProvider.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * This file is part of the Cilex framework.
+ *
+ * (c) Mike van Riel <mike.vanriel@naenius.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cilex\Provider;
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+/**
+ * Monolog Provider.
+ *
+ * This class is an adaptation of the Silex MonologServiceProvider written by
+ * Fabien Potencier.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Mike van Riel <mike.vanvriel@naenius.com>
+ */
+class MonologServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app['monolog'] = function () use ($app) {
+            $log = new Logger(isset($app['monolog.name']) ? $app['monolog.name'] : 'myapp');
+            $app['monolog.configure']($log);
+
+            return $log;
+        };
+
+        $app['monolog.configure'] = $app->protect(
+            function ($log) use ($app) {
+                $log->pushHandler($app['monolog.handler']);
+            }
+        );
+
+        $app['monolog.handler'] = function () use ($app) {
+            return new StreamHandler($app['monolog.logfile'], $app['monolog.level']);
+        };
+
+        if (!isset($app['monolog.level'])) {
+            $app['monolog.level'] = function () {
+                return Logger::DEBUG;
+            };
+        }
+
+        if (isset($app['monolog.class_path'])) {
+            $app['autoloader']->registerNamespace('Monolog', $app['monolog.class_path']);
+        }
+    }
+}

--- a/src/Cilex/Provider/ValidatorServiceProvider.php
+++ b/src/Cilex/Provider/ValidatorServiceProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Cilex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cilex\Provider;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+use Symfony\Component\Validator\Validator;
+use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
+use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\DefaultTranslator;
+
+/**
+ * Symfony Validator component Provider.
+ *
+ * This class is an adaptation of the Silex MonologServiceProvider written by
+ * Fabien Potencier.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Mike van Riel <mike.vanvriel@naenius.com>
+ */
+class ValidatorServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app['validator'] = function ($app) {
+            return new Validator(
+                $app['validator.mapping.class_metadata_factory'],
+                $app['validator.validator_factory'],
+                $app['validator.default_translator']
+            );
+        };
+
+        $app['validator.mapping.class_metadata_factory'] = function () {
+            return new ClassMetadataFactory(new StaticMethodLoader());
+        };
+
+        $app['validator.validator_factory'] = function () {
+            return new ConstraintValidatorFactory();
+        };
+
+        $app['validator.default_translator'] = function () {
+            if (!class_exists('Symfony\\Component\\Validator\\DefaultTranslator')) {
+                return array();
+            }
+
+            return new DefaultTranslator();
+        };
+
+        if (isset($app['validator.class_path'])) {
+            $app['autoloader']->registerNamespace('Symfony\\Component\\Validator', $app['validator.class_path']);
+        }
+    }
+}

--- a/src/phpDocumentor/Application.php
+++ b/src/phpDocumentor/Application.php
@@ -41,12 +41,12 @@ class Application extends Cilex
      * Initializes all components used by phpDocumentor.
      *
      * @param ClassLoader $autoloader
-     * @param array       $values
+     * @param array $values
      */
     public function __construct($autoloader = null, array $values = array())
     {
         $this->defineIniSettings();
-        
+
         self::$VERSION = strpos('@package_version@', '@') === 0
             ? trim(file_get_contents(__DIR__ . '/../../VERSION'))
             : '@package_version@';
@@ -127,11 +127,11 @@ class Application extends Cilex
                 break;
         }
 
-        $this['monolog.level']   = $level;
+        $this['monolog.level'] = $level;
         if ($logPath) {
             $logPath = str_replace(
                 array('{APP_ROOT}', '{DATE}'),
-                array(realpath(__DIR__.'/../..'), $this['kernel.timer.start']),
+                array(realpath(__DIR__ . '/../..'), $this['kernel.timer.start']),
                 $logPath
             );
             $this['monolog.logfile'] = $logPath;
@@ -169,7 +169,7 @@ class Application extends Cilex
      */
     public function run($interactive = false)
     {
-        /** @var ConsoleApplication $app  */
+        /** @var ConsoleApplication $app */
         $app = $this['console'];
         $app->setAutoExit(false);
 
@@ -281,11 +281,9 @@ class Application extends Cilex
      */
     protected function addEventDispatcher()
     {
-        $this['event_dispatcher'] = $this->share(
-            function () {
-                return Event\Dispatcher::getInstance();
-            }
-        );
+        $this['event_dispatcher'] = function () {
+            return Event\Dispatcher::getInstance();
+        };
     }
 
     /**

--- a/src/phpDocumentor/Command/Command.php
+++ b/src/phpDocumentor/Command/Command.php
@@ -12,6 +12,7 @@
 
 namespace phpDocumentor\Command;
 
+use Cilex\Provider\Console\Command as BaseCommand;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Console\Input\InputInterface;
  * Includes additional methods to forward the output to the logging events
  * of phpDocumentor.
  */
-class Command extends \Cilex\Command\Command
+class Command extends BaseCommand
 {
     /**
      * Registers the current command.

--- a/src/phpDocumentor/Configuration/ServiceProvider.php
+++ b/src/phpDocumentor/Configuration/ServiceProvider.php
@@ -12,9 +12,9 @@
 namespace phpDocumentor\Configuration;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use Doctrine\Common\Annotations\AnnotationReader;
-use JMS\Serializer\Serializer;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -48,9 +48,9 @@ class ServiceProvider implements ServiceProviderInterface
      * The user config file (either phpdoc.dist.xml or phpdoc.xml) is merged
      * with the template file.
      *
-     * @param Application $app An Application instance
+     * @param Container $app An Application instance
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         $this->addMerger($app);
 
@@ -75,13 +75,11 @@ class ServiceProvider implements ServiceProviderInterface
             . ((file_exists(getcwd() . '/phpdoc.xml')) ? '/phpdoc.xml' : '/phpdoc.dist.xml');
         $app['config.class'] = 'phpDocumentor\Configuration';
 
-        $app['config'] = $app->share(
-            function ($app) {
-                $loader = new Loader($app['serializer'], $app['config.merger']);
+        $app['config'] = function ($app) {
+            $loader = new Loader($app['serializer'], $app['config.merger']);
 
-                return $loader->load($app['config.path.template'], $app['config.path.user'], $app['config.class']);
-            }
-        );
+            return $loader->load($app['config.path.template'], $app['config.path.user'], $app['config.class']);
+        };
     }
 
     /**
@@ -95,11 +93,9 @@ class ServiceProvider implements ServiceProviderInterface
     {
         $this->addMergerAnnotations($container);
 
-        $container['config.merger'] = $container->share(
-            function () {
-                return new Merger(new AnnotationReader());
-            }
-        );
+        $container['config.merger'] = function () {
+            return new Merger(new AnnotationReader());
+        };
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/ServiceProvider.php
+++ b/src/phpDocumentor/Descriptor/ServiceProvider.php
@@ -12,7 +12,8 @@
 namespace phpDocumentor\Descriptor;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use phpDocumentor\Descriptor\Builder\AssemblerFactory;
 use phpDocumentor\Descriptor\Builder\Reflector\ArgumentAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\ClassAssembler;
@@ -35,7 +36,6 @@ use phpDocumentor\Descriptor\Builder\Reflector\Tags\ReturnAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\SeeAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\SinceAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\ThrowsAssembler;
-use phpDocumentor\Descriptor\Builder\Reflector\Tags\TypeCollectionAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\UsesAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\VarAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\VersionAssembler;
@@ -86,11 +86,11 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Adds the services needed to build the descriptors.
      *
-     * @param Application $app An Application instance
+     * @param Container $app An Application instance
      *
      * @return void
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         $app['parser.example.finder'] = new ExampleFinder();
 
@@ -111,7 +111,7 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers the Assemblers used to convert Reflection objects to Descriptors.
      *
-     * @param AssemblerFactory   $factory
+     * @param AssemblerFactory $factory
      * @param \Cilex\Application $app
      *
      * @return AssemblerFactory
@@ -119,37 +119,85 @@ class ServiceProvider implements ServiceProviderInterface
     public function attachAssemblersToFactory(AssemblerFactory $factory, Application $app)
     {
         // @codingStandardsIgnoreStart because we limit the verbosity by making all closures single-line
-        $fileMatcher      = function ($criteria) { return $criteria instanceof File; };
-        $constantMatcher  = function ($criteria) {
+        $fileMatcher = function ($criteria) {
+            return $criteria instanceof File;
+        };
+        $constantMatcher = function ($criteria) {
             return $criteria instanceof Constant; // || $criteria instanceof ClassConstant;
         };
-        $traitMatcher     = function ($criteria) { return $criteria instanceof Trait_; };
-        $classMatcher     = function ($criteria) { return $criteria instanceof Class_; };
-        $interfaceMatcher = function ($criteria) { return $criteria instanceof Interface_; };
-        $propertyMatcher  = function ($criteria) { return $criteria instanceof Property; };
-        $methodMatcher    = function ($criteria) { return $criteria instanceof Method; };
-        $argumentMatcher  = function ($criteria) { return $criteria instanceof Argument; };
-        $functionMatcher  = function ($criteria) { return $criteria instanceof Function_; };
-        $namespaceMatcher  = function ($criteria) { return $criteria instanceof Namespace_; };
+        $traitMatcher = function ($criteria) {
+            return $criteria instanceof Trait_;
+        };
+        $classMatcher = function ($criteria) {
+            return $criteria instanceof Class_;
+        };
+        $interfaceMatcher = function ($criteria) {
+            return $criteria instanceof Interface_;
+        };
+        $propertyMatcher = function ($criteria) {
+            return $criteria instanceof Property;
+        };
+        $methodMatcher = function ($criteria) {
+            return $criteria instanceof Method;
+        };
+        $argumentMatcher = function ($criteria) {
+            return $criteria instanceof Argument;
+        };
+        $functionMatcher = function ($criteria) {
+            return $criteria instanceof Function_;
+        };
+        $namespaceMatcher = function ($criteria) {
+            return $criteria instanceof Namespace_;
+        };
 
-        $authorMatcher      = function ($criteria) { return $criteria instanceof Author; };
-        $deprecatedMatcher  = function ($criteria) { return $criteria instanceof Deprecated; };
-        $exampleMatcher     = function ($criteria) { return $criteria instanceof Example; };
-        $linkMatcher        = function ($criteria) { return $criteria instanceof Link; };
-        $methodTagMatcher   = function ($criteria) { return $criteria instanceof Tags\Method; };
-        $propertyTagMatcher = function ($criteria) { return $criteria instanceof Tags\Property; };
-        $paramMatcher       = function ($criteria) { return $criteria instanceof Param; };
-        $throwsMatcher      = function ($criteria) { return $criteria instanceof Throws; };
-        $returnMatcher      = function ($criteria) { return $criteria instanceof Return_; };
-        $usesMatcher        = function ($criteria) { return $criteria instanceof Uses; };
-        $seeMatcher         = function ($criteria) { return $criteria instanceof See; };
-        $sinceMatcher       = function ($criteria) { return $criteria instanceof Since; };
-        $varMatcher         = function ($criteria) { return $criteria instanceof Var_; };
-        $versionMatcher     = function ($criteria) { return $criteria instanceof Version; };
+        $authorMatcher = function ($criteria) {
+            return $criteria instanceof Author;
+        };
+        $deprecatedMatcher = function ($criteria) {
+            return $criteria instanceof Deprecated;
+        };
+        $exampleMatcher = function ($criteria) {
+            return $criteria instanceof Example;
+        };
+        $linkMatcher = function ($criteria) {
+            return $criteria instanceof Link;
+        };
+        $methodTagMatcher = function ($criteria) {
+            return $criteria instanceof Tags\Method;
+        };
+        $propertyTagMatcher = function ($criteria) {
+            return $criteria instanceof Tags\Property;
+        };
+        $paramMatcher = function ($criteria) {
+            return $criteria instanceof Param;
+        };
+        $throwsMatcher = function ($criteria) {
+            return $criteria instanceof Throws;
+        };
+        $returnMatcher = function ($criteria) {
+            return $criteria instanceof Return_;
+        };
+        $usesMatcher = function ($criteria) {
+            return $criteria instanceof Uses;
+        };
+        $seeMatcher = function ($criteria) {
+            return $criteria instanceof See;
+        };
+        $sinceMatcher = function ($criteria) {
+            return $criteria instanceof Since;
+        };
+        $varMatcher = function ($criteria) {
+            return $criteria instanceof Var_;
+        };
+        $versionMatcher = function ($criteria) {
+            return $criteria instanceof Version;
+        };
 
         //$typeCollectionMatcher = function ($criteria) { return $criteria instanceof TypeCollection; };
 
-        $tagFallbackMatcher = function ($criteria) { return $criteria instanceof Tag; };
+        $tagFallbackMatcher = function ($criteria) {
+            return $criteria instanceof Tag;
+        };
         // @codingStandardsIgnoreEnd
 
         $argumentAssembler = new ArgumentAssembler();
@@ -227,21 +275,21 @@ class ServiceProvider implements ServiceProviderInterface
     public function attachValidators(Validator $validator)
     {
         /** @var ClassMetadata $fileMetadata */
-        $fileMetadata  = $validator->getMetadataFor('phpDocumentor\Descriptor\FileDescriptor');
+        $fileMetadata = $validator->getMetadataFor('phpDocumentor\Descriptor\FileDescriptor');
         /** @var ClassMetadata $constantMetadata */
-        $constantMetadata  = $validator->getMetadataFor('phpDocumentor\Descriptor\ConstantDescriptor');
+        $constantMetadata = $validator->getMetadataFor('phpDocumentor\Descriptor\ConstantDescriptor');
         /** @var ClassMetadata $functionMetadata */
-        $functionMetadata  = $validator->getMetadataFor('phpDocumentor\Descriptor\FunctionDescriptor');
+        $functionMetadata = $validator->getMetadataFor('phpDocumentor\Descriptor\FunctionDescriptor');
         /** @var ClassMetadata $classMetadata */
-        $classMetadata     = $validator->getMetadataFor('phpDocumentor\Descriptor\ClassDescriptor');
+        $classMetadata = $validator->getMetadataFor('phpDocumentor\Descriptor\ClassDescriptor');
         /** @var ClassMetadata $interfaceMetadata */
         $interfaceMetadata = $validator->getMetadataFor('phpDocumentor\Descriptor\InterfaceDescriptor');
         /** @var ClassMetadata $traitMetadata */
-        $traitMetadata     = $validator->getMetadataFor('phpDocumentor\Descriptor\TraitDescriptor');
+        $traitMetadata = $validator->getMetadataFor('phpDocumentor\Descriptor\TraitDescriptor');
         /** @var ClassMetadata $propertyMetadata */
-        $propertyMetadata  = $validator->getMetadataFor('phpDocumentor\Descriptor\PropertyDescriptor');
+        $propertyMetadata = $validator->getMetadataFor('phpDocumentor\Descriptor\PropertyDescriptor');
         /** @var ClassMetadata $methodMetadata */
-        $methodMetadata    = $validator->getMetadataFor('phpDocumentor\Descriptor\MethodDescriptor');
+        $methodMetadata = $validator->getMetadataFor('phpDocumentor\Descriptor\MethodDescriptor');
 
         $fileMetadata->addPropertyConstraint('summary', new Assert\NotBlank(array('message' => 'PPC:ERR-50000')));
         $classMetadata->addPropertyConstraint('summary', new Assert\NotBlank(array('message' => 'PPC:ERR-50005')));
@@ -286,29 +334,27 @@ class ServiceProvider implements ServiceProviderInterface
      */
     protected function addCache(Application $app)
     {
-        $app['descriptor.cache'] = $app->share(
-            function () {
-                $cache = new Filesystem();
-                $cache->setOptions(
-                    array(
-                         'namespace' => 'phpdoc-cache',
-                         'cache_dir' => sys_get_temp_dir(),
-                    )
-                );
-                $plugin = new SerializerPlugin();
+        $app['descriptor.cache'] = function () {
+            $cache = new Filesystem();
+            $cache->setOptions(
+                array(
+                    'namespace' => 'phpdoc-cache',
+                    'cache_dir' => sys_get_temp_dir(),
+                )
+            );
+            $plugin = new SerializerPlugin();
 
-                if (extension_loaded('igbinary')) {
-                    $options = new PluginOptions();
-                    $options->setSerializer('igbinary');
+            if (extension_loaded('igbinary')) {
+                $options = new PluginOptions();
+                $options->setSerializer('igbinary');
 
-                    $plugin->setOptions($options);
-                }
-
-                $cache->addPlugin($plugin);
-
-                return $cache;
+                $plugin->setOptions($options);
             }
-        );
+
+            $cache->addPlugin($plugin);
+
+            return $cache;
+        };
     }
 
     /**
@@ -329,18 +375,16 @@ class ServiceProvider implements ServiceProviderInterface
             $app['descriptor.builder.serializer'] = 'PhpSerialize';
         }
 
-        $app['descriptor.builder'] = $app->share(
-            function ($container) {
-                $builder = new ProjectDescriptorBuilder(
-                    $container['descriptor.builder.assembler.factory'],
-                    $container['descriptor.filter'],
-                    $container['validator']
-                );
-                $builder->setTranslator($container['translator']);
+        $app['descriptor.builder'] = function ($container) {
+            $builder = new ProjectDescriptorBuilder(
+                $container['descriptor.builder.assembler.factory'],
+                $container['descriptor.filter'],
+                $container['validator']
+            );
+            $builder->setTranslator($container['translator']);
 
-                return $builder;
-            }
-        );
+            return $builder;
+        };
     }
 
     /**
@@ -352,20 +396,16 @@ class ServiceProvider implements ServiceProviderInterface
      */
     protected function addAssemblers(Application $app)
     {
-        $app['descriptor.builder.assembler.factory'] = $app->share(
-            function () {
-                return new AssemblerFactory();
-            }
-        );
+        $app['descriptor.builder.assembler.factory'] = function () {
+            return new AssemblerFactory();
+        };
 
         $provider = $this;
-        $app['descriptor.builder.assembler.factory'] = $app->share(
-            $app->extend(
-                'descriptor.builder.assembler.factory',
-                function ($factory) use ($provider, $app) {
-                    return $provider->attachAssemblersToFactory($factory, $app);
-                }
-            )
+        $app['descriptor.builder.assembler.factory'] = $app->extend(
+            'descriptor.builder.assembler.factory',
+            function ($factory) use ($provider, $app) {
+                return $provider->attachAssemblersToFactory($factory, $app);
+            }
         );
     }
 
@@ -381,11 +421,9 @@ class ServiceProvider implements ServiceProviderInterface
      */
     protected function addFilters(Application $app)
     {
-        $app['descriptor.filter'] = $app->share(
-            function () {
-                return new Filter(new ClassFactory());
-            }
-        );
+        $app['descriptor.filter'] = function () {
+            return new Filter(new ClassFactory());
+        };
     }
 
     /**
@@ -404,13 +442,11 @@ class ServiceProvider implements ServiceProviderInterface
         }
 
         $provider = $this;
-        $app['validator'] = $app->share(
-            $app->extend(
-                'validator',
-                function ($validatorManager) use ($provider) {
-                    return $provider->attachValidators($validatorManager);
-                }
-            )
+        $app['validator'] = $app->extend(
+            'validator',
+            function ($validatorManager) use ($provider) {
+                return $provider->attachValidators($validatorManager);
+            }
         );
     }
 }

--- a/src/phpDocumentor/Partials/ServiceProvider.php
+++ b/src/phpDocumentor/Partials/ServiceProvider.php
@@ -12,7 +12,8 @@
 namespace phpDocumentor\Partials;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use phpDocumentor\Configuration as ApplicationConfiguration;
 use phpDocumentor\Partials\Collection as PartialsCollection;
 use phpDocumentor\Translator\Translator;
@@ -31,7 +32,7 @@ class ServiceProvider implements ServiceProviderInterface
      *
      * @return void
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         /** @var Translator $translator  */
         $translator = $app['translator'];

--- a/src/phpDocumentor/Plugin/Core/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/Core/ServiceProvider.php
@@ -12,7 +12,8 @@
 namespace phpDocumentor\Plugin\Core;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use phpDocumentor\Translator\Translator;
 use phpDocumentor\Plugin\Core\Transformer\Writer;
 use phpDocumentor\Transformer\Writer\Collection;
@@ -29,11 +30,11 @@ final class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers services on the given app.
      *
-     * @param Application $app An Application instance.
+     * @param Container $app An Application instance.
      *
      * @return void
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         $this->registerTranslationMessages($app);
         $this->registerWriters($app);

--- a/src/phpDocumentor/Plugin/Graphs/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/Graphs/ServiceProvider.php
@@ -12,7 +12,8 @@
 namespace phpDocumentor\Plugin\Graphs;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use phpDocumentor\Plugin\Graphs\Writer\Graph;
 use phpDocumentor\Transformer\Writer\Collection;
 
@@ -21,9 +22,9 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers services on the given app.
      *
-     * @param Application $app An Application instance.
+     * @param Container $app An Application instance.
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         /** @var Collection $writerCollection */
         $writerCollection = $app['transformer.writer.collection'];

--- a/src/phpDocumentor/Plugin/LegacyNamespaceConverter/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/LegacyNamespaceConverter/ServiceProvider.php
@@ -12,7 +12,8 @@
 namespace phpDocumentor\Plugin\LegacyNamespaceConverter;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use phpDocumentor\Plugin\Plugin;
 use phpDocumentor\Descriptor\Filter\Filter;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
@@ -49,9 +50,9 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers services on the given app.
      *
-     * @param Application $app An Application instance.
+     * @param Container $app An Application instance.
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         $this->addNamespaceFilter($app['descriptor.builder'], $app['descriptor.filter']);
     }

--- a/src/phpDocumentor/Plugin/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/ServiceProvider.php
@@ -3,12 +3,16 @@
 namespace phpDocumentor\Plugin;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use phpDocumentor\Configuration as ApplicationConfiguration;
 
 class ServiceProvider implements ServiceProviderInterface
 {
-    public function register(Application $app)
+    /**
+     * @param Container $app
+     */
+    public function register(Container $app)
     {
         /** @var ApplicationConfiguration $config */
         $config = $app['config'];

--- a/src/phpDocumentor/Plugin/Twig/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/Twig/ServiceProvider.php
@@ -12,7 +12,8 @@
 namespace phpDocumentor\Plugin\Twig;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use phpDocumentor\Translator\Translator;
 use phpDocumentor\Transformer\Writer\Collection;
 
@@ -29,9 +30,9 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers services on the given app.
      *
-     * @param Application $app An Application instance.
+     * @param Container $app An Application instance.
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         /** @var Translator $translator  */
         $translator = $app['translator'];

--- a/src/phpDocumentor/Transformer/Command/Template/ListCommand.php
+++ b/src/phpDocumentor/Transformer/Command/Template/ListCommand.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Command\Template;
 
-use Cilex\Command\Command;
+use phpDocumentor\Command\Command;
 use phpDocumentor\Transformer\Template\Factory;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;

--- a/src/phpDocumentor/Translator/ServiceProvider.php
+++ b/src/phpDocumentor/Translator/ServiceProvider.php
@@ -12,7 +12,8 @@
 namespace phpDocumentor\Translator;
 
 use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use phpDocumentor\Configuration as ApplicationConfiguration;
 
 /**
@@ -31,22 +32,20 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers the translator using the currently active locale.
      *
-     * @param Application $app
+     * @param Container $app
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         /** @var ApplicationConfiguration $config */
         $config = $app['config'];
 
         $app['translator.locale'] = $config->getTranslator()->getLocale();
 
-        $app['translator'] = $app->share(
-            function ($app) {
-                $translator = new Translator();
-                $translator->setLocale($app['translator.locale']);
+        $app['translator'] = function ($app) {
+            $translator = new Translator();
+            $translator->setLocale($app['translator.locale']);
 
-                return $translator;
-            }
-        );
+            return $translator;
+        };
     }
 }


### PR DESCRIPTION
These changes contain the upgrade to cilex v2 and pimple v3.
This allows us to move forward with a bunch of other dependencies like
validator and filters to be able to get rid of all deprecated warnings.