### PR TITLE
Feature/remove cilex

### DIFF
--- a/box.json
+++ b/box.json
@@ -19,7 +19,6 @@
                 "tests"
             ],
             "in": [
-                "vendor/cilex/cilex/src",
                 "vendor/composer",
                 "vendor/container-interop",
                 "vendor/doctrine/annotations/lib",
@@ -48,7 +47,6 @@
                 "vendor/psr/cache/src",
                 "vendor/psr/container/src",
                 "vendor/psr/log/Psr",
-                "vendor/silex/api",
                 "vendor/symfony",
                 "vendor/tedivm/stash",
                 "vendor/twig/twig/lib",
@@ -69,7 +67,6 @@
                 "tests"
             ],
             "in": [
-                "vendor/cilex/cilex/src",
                 "vendor/composer",
                 "vendor/container-interop",
                 "vendor/doctrine/annotations/lib",
@@ -98,7 +95,6 @@
                 "vendor/psr/cache/src",
                 "vendor/psr/container/src",
                 "vendor/psr/log/Psr",
-                "vendor/silex/api",
                 "vendor/symfony",
                 "vendor/tedivm/stash",
                 "vendor/twig/twig/lib",

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,6 @@
     },
     "require": {
         "php": ">=7.0",
-
-        "cilex/cilex":        "^2.0",
         "symfony/console":    "~2.3",
 
         "monolog/monolog":  "~1.6",
@@ -55,7 +53,8 @@
         "webmozart/assert": "^1.2",
         "padraic/phar-updater": "^1.0",
         "tedivm/stash": "^0.14.2",
-        "phpdocumentor/flyfinder": "@beta"
+        "phpdocumentor/flyfinder": "@beta",
+        "pimple/pimple": "^3.2"
     },
     "minimum-stability": "stable",
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,66 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "32af363b5002147d570061a14ba7c2df",
+    "content-hash": "514bf887d7cd2c62fc60502b8530c85a",
     "packages": [
-        {
-            "name": "cilex/cilex",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Cilex/Cilex.git",
-                "reference": "c5612545cceac9fadc6ad6dcf6ba28fb0c80c460"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Cilex/Cilex/zipball/c5612545cceac9fadc6ad6dcf6ba28fb0c80c460",
-                "reference": "c5612545cceac9fadc6ad6dcf6ba28fb0c80c460",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "pimple/pimple": "^3.0",
-                "silex/api": "^2.0",
-                "symfony/console": "^2.7 || ^3.0",
-                "symfony/event-dispatcher": "^2.7 || ^3.0",
-                "symfony/process": "^2.7 || ^3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~3.7"
-            },
-            "suggest": {
-                "symfony/validator": "^2.7 || ^3.0",
-                "symfony/yaml": "^2.7 || ^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-develop": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Cilex\\": "src/Cilex"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "The PHP micro-framework for Command line tools based on the Symfony2 Components",
-            "homepage": "http://cilex.github.com",
-            "keywords": [
-                "cli",
-                "microframework"
-            ],
-            "time": "2016-11-20T14:31:12+00:00"
-        },
         {
             "name": "container-interop/container-interop",
             "version": "1.2.0",
@@ -1422,60 +1364,6 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
-        },
-        {
-            "name": "silex/api",
-            "version": "v2.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/silexphp/Silex-Api.git",
-                "reference": "69617ecf52581bbd6b315424f45b40783189e902"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Silex-Api/zipball/69617ecf52581bbd6b315424f45b40783189e902",
-                "reference": "69617ecf52581bbd6b315424f45b40783189e902",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "pimple/pimple": "~3.0"
-            },
-            "suggest": {
-                "silex/silex": "For BootableProviderInterface and ControllerProviderInterface",
-                "symfony/event-dispatcher": "For EventListenerProviderInterface"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Silex\\Api\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                }
-            ],
-            "description": "The Silex interfaces",
-            "homepage": "http://silex.sensiolabs.org",
-            "keywords": [
-                "microframework"
-            ],
-            "time": "2017-07-23T07:40:14+00:00"
         },
         {
             "name": "symfony/config",

--- a/src/phpDocumentor/Command/Command.php
+++ b/src/phpDocumentor/Command/Command.php
@@ -12,7 +12,6 @@
 
 namespace phpDocumentor\Command;
 
-use Cilex\Provider\Console\Command as BaseCommand;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,7 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
  * Includes additional methods to forward the output to the logging events
  * of phpDocumentor.
  */
-class Command extends BaseCommand
+class Command extends \Symfony\Component\Console\Command\Command
 {
     /**
      * Registers the current command.

--- a/src/phpDocumentor/Command/Project/RunCommand.php
+++ b/src/phpDocumentor/Command/Project/RunCommand.php
@@ -38,6 +38,22 @@ use Symfony\Component\Console\Output\OutputInterface;
 class RunCommand extends Command
 {
     /**
+     * @var ProjectDescriptorBuilder
+     */
+    private $projectDescriptorBuilder;
+
+    /**
+     * RunCommand constructor.
+     */
+    public function __construct(ProjectDescriptorBuilder $projectDescriptorBuilder)
+    {
+
+        parent::__construct('project:run');
+        $this->projectDescriptorBuilder = $projectDescriptorBuilder;
+    }
+
+
+    /**
      * Initializes this command and sets the name, description, options and
      * arguments.
      *
@@ -278,9 +294,7 @@ HELP
         }
 
         if ($output->getVerbosity() === OutputInterface::VERBOSITY_DEBUG) {
-            /** @var ProjectDescriptorBuilder $descriptorBuilder */
-            $descriptorBuilder = $this->getService('descriptor.builder');
-            file_put_contents('ast.dump', serialize($descriptorBuilder->getProjectDescriptor()));
+            file_put_contents('ast.dump', serialize($this->projectDescriptorBuilder->getProjectDescriptor()));
         }
 
         return 0;

--- a/src/phpDocumentor/Configuration/ServiceProvider.php
+++ b/src/phpDocumentor/Configuration/ServiceProvider.php
@@ -85,11 +85,11 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Initializes and adds the configuration merger object as the 'config.merger' service to the container.
      *
-     * @param Application $container
+     * @param Container $container
      *
      * @return void
      */
-    private function addMerger(Application $container)
+    private function addMerger(Container $container)
     {
         $this->addMergerAnnotations($container);
 
@@ -101,14 +101,14 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Adds the annotations for the Merger component to the Serializer.
      *
-     * @param Application $container
+     * @param Container $container
      *
      * @throws \RuntimeException if the annotation handler for Jms Serializer is not added to the container as
      *   'serializer.annotations' service.
      *
      * @return void
      */
-    private function addMergerAnnotations(Application $container)
+    private function addMergerAnnotations(Container $container)
     {
         if (!isset($container['serializer.annotations'])) {
             throw new \RuntimeException(

--- a/src/phpDocumentor/Descriptor/ServiceProvider.php
+++ b/src/phpDocumentor/Descriptor/ServiceProvider.php
@@ -111,11 +111,11 @@ class ServiceProvider implements ServiceProviderInterface
      * Registers the Assemblers used to convert Reflection objects to Descriptors.
      *
      * @param AssemblerFactory $factory
-     * @param \Cilex\Application $app
+     * @param Container $app
      *
      * @return AssemblerFactory
      */
-    public function attachAssemblersToFactory(AssemblerFactory $factory, Application $app)
+    public function attachAssemblersToFactory(AssemblerFactory $factory, Container $app)
     {
         // @codingStandardsIgnoreStart because we limit the verbosity by making all closures single-line
         $fileMatcher = function ($criteria) {
@@ -237,16 +237,16 @@ class ServiceProvider implements ServiceProviderInterface
      * Attaches filters to the manager.
      *
      * @param Filter $filterManager
-     * @param Application $app
+     * @param Container $container
      *
      * @return Filter
      */
-    public function attachFiltersToManager(Filter $filterManager, Application $app)
+    public function attachFiltersToManager(Filter $filterManager, Container $container)
     {
-        $stripOnVisibility = new StripOnVisibility($app['descriptor.builder']);
+        $stripOnVisibility = new StripOnVisibility($container['descriptor.builder']);
         $filtersOnAllDescriptors = array(
-            new StripInternal($app['descriptor.builder']),
-            new StripIgnore($app['descriptor.builder'])
+            new StripInternal($container['descriptor.builder']),
+            new StripIgnore($container['descriptor.builder'])
         );
 
         foreach ($filtersOnAllDescriptors as $filter) {
@@ -267,13 +267,13 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Adds the caching mechanism to the dependency injection container with key 'descriptor.cache'.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return void
      */
-    protected function addCache(Application $app)
+    protected function addCache(Container $container)
     {
-        $app['descriptor.cache'] = function () {
+        $container['descriptor.cache'] = function () {
             $cache = new Filesystem();
             $cache->setOptions(
                 array(
@@ -302,19 +302,19 @@ class ServiceProvider implements ServiceProviderInterface
      * Please note that the type of serializer can be configured using the parameter 'descriptor.builder.serializer'; it
      * accepts any parameter that Zend\Serializer supports.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return void
      */
-    protected function addBuilder(Application $app)
+    protected function addBuilder(Container $container)
     {
         if (extension_loaded('igbinary')) {
-            $app['descriptor.builder.serializer'] = 'IgBinary';
+            $container['descriptor.builder.serializer'] = 'IgBinary';
         } else {
-            $app['descriptor.builder.serializer'] = 'PhpSerialize';
+            $container['descriptor.builder.serializer'] = 'PhpSerialize';
         }
 
-        $app['descriptor.builder'] = function ($container) {
+        $container['descriptor.builder'] = function ($container) {
             $builder = new ProjectDescriptorBuilder(
                 $container['descriptor.builder.assembler.factory'],
                 $container['descriptor.filter']
@@ -328,21 +328,21 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Adds the assembler factory and attaches the basic assemblers with key 'descriptor.builder.assembler.factory'.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return void
      */
-    protected function addAssemblers(Application $app)
+    protected function addAssemblers(Container $container)
     {
-        $app['descriptor.builder.assembler.factory'] = function () {
+        $container['descriptor.builder.assembler.factory'] = function () {
             return new AssemblerFactory();
         };
 
         $provider = $this;
-        $app['descriptor.builder.assembler.factory'] = $app->extend(
+        $container['descriptor.builder.assembler.factory'] = $container->extend(
             'descriptor.builder.assembler.factory',
-            function ($factory) use ($provider, $app) {
-                return $provider->attachAssemblersToFactory($factory, $app);
+            function ($factory) use ($provider, $container) {
+                return $provider->attachAssemblersToFactory($factory, $container);
             }
         );
     }
@@ -353,13 +353,13 @@ class ServiceProvider implements ServiceProviderInterface
      * Please note that filters can only be attached after the builder is instantiated because it is needed; so the
      * filters can be attached by extending 'descriptor.builder'.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return void
      */
-    protected function addFilters(Application $app)
+    protected function addFilters(Container $container)
     {
-        $app['descriptor.filter'] = function () {
+        $container['descriptor.filter'] = function () {
             return new Filter(new ClassFactory());
         };
     }

--- a/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
+++ b/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
@@ -74,6 +74,10 @@ class ParseCommand extends Command
      * @var FileCollector
      */
     private $fileCollector;
+    /**
+     * @var CacheMiddleware
+     */
+    private $cacheMiddleware;
 
     /**
      * ParseCommand constructor.
@@ -84,6 +88,7 @@ class ParseCommand extends Command
      * @param StorageInterface $cache
      * @param ExampleFinder $exampleFinder
      * @param PartialsCollection $partials
+     * @param CacheMiddleware $cacheMiddleware
      */
     public function __construct(
         ProjectDescriptorBuilder $builder,
@@ -92,7 +97,8 @@ class ParseCommand extends Command
         Translator $translator,
         StorageInterface $cache,
         ExampleFinder $exampleFinder,
-        PartialsCollection $partials
+        PartialsCollection $partials,
+        CacheMiddleware $cacheMiddleware
     ) {
         $this->builder = $builder;
         $this->parser = $parser;
@@ -103,6 +109,7 @@ class ParseCommand extends Command
         $this->fileCollector = $fileCollector;
 
         parent::__construct('project:parse');
+        $this->cacheMiddleware = $cacheMiddleware;
     }
 
     /**
@@ -419,6 +426,6 @@ class ParseCommand extends Command
 
     private function getCacheMiddleware(): CacheMiddleware
     {
-        return $this->getContainer()->offsetGet('parser.middleware.cache');
+        return $this->cacheMiddleware;
     }
 }

--- a/src/phpDocumentor/Parser/ServiceProvider.php
+++ b/src/phpDocumentor/Parser/ServiceProvider.php
@@ -40,7 +40,7 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers services on the given app.
      *
-     * @param Container|Application $app An Application instance
+     * @param Container $app An Application instance
      *
      * @throws Exception\MissingDependencyException if the Descriptor Builder is not present.
      * @throws \Stash\Exception\RuntimeException

--- a/src/phpDocumentor/Parser/ServiceProvider.php
+++ b/src/phpDocumentor/Parser/ServiceProvider.php
@@ -105,18 +105,17 @@ class ServiceProvider implements ServiceProviderInterface
             new FlySystemFactory(new MountManager())
         );
 
-        if ($app instanceof Application) {
-            $app->command(
-                new ParseCommand(
-                    $app['descriptor.builder'],
-                    $app['parser'],
-                    $fileCollector,
-                    $translator,
-                    $app['descriptor.cache'],
-                    $app['parser.example.finder'],
-                    $app['partials']
-                )
-            );
-        }
+        $app['console']->add(
+            new ParseCommand(
+                $app['descriptor.builder'],
+                $app['parser'],
+                $fileCollector,
+                $translator,
+                $app['descriptor.cache'],
+                $app['parser.example.finder'],
+                $app['partials'],
+                $app['parser.middleware.cache']
+            )
+        );
     }
 }

--- a/src/phpDocumentor/Partials/ServiceProvider.php
+++ b/src/phpDocumentor/Partials/ServiceProvider.php
@@ -26,7 +26,7 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers services on the given app.
      *
-     * @param Application $app An Application instance
+     * @param Container $app An Application instance
      *
      * @throws Exception\MissingNameForPartialException if a partial has no name provided.
      *

--- a/src/phpDocumentor/Plugin/Core/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/Core/ServiceProvider.php
@@ -49,35 +49,35 @@ final class ServiceProvider implements ServiceProviderInterface
      *
      * This action will enable transformations in templates to make use of these writers.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return void
      */
-    private function registerWriters(Application $app)
+    private function registerWriters(Container $container)
     {
-        $writerCollection = $this->getWriterCollection($app);
+        $writerCollection = $this->getWriterCollection($container);
 
         $writerCollection['FileIo'] = new Writer\FileIo();
         $writerCollection['checkstyle'] = new Writer\Checkstyle();
         $writerCollection['sourcecode'] = new Writer\Sourcecode();
         $writerCollection['statistics'] = new Writer\Statistics();
-        $writerCollection['xml'] = new Writer\Xml($app['transformer.routing.standard']);
-        $writerCollection['xsl'] = new Writer\Xsl($app['monolog']);
+        $writerCollection['xml'] = new Writer\Xml($container['transformer.routing.standard']);
+        $writerCollection['xsl'] = new Writer\Xsl($container['monolog']);
 
-        $writerCollection['checkstyle']->setTranslator($this->getTranslator($app));
-        $writerCollection['xml']->setTranslator($this->getTranslator($app));
+        $writerCollection['checkstyle']->setTranslator($this->getTranslator($container));
+        $writerCollection['xml']->setTranslator($this->getTranslator($container));
     }
 
     /**
      * Registers the Messages folder in this plugin as a source of translations.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return void
      */
-    private function registerTranslationMessages(Application $app)
+    private function registerTranslationMessages(Container $container)
     {
-        $this->getTranslator($app)->addTranslationFolder(__DIR__ . DIRECTORY_SEPARATOR . 'Messages');
+        $this->getTranslator($container)->addTranslationFolder(__DIR__ . DIRECTORY_SEPARATOR . 'Messages');
     }
 
     /**
@@ -89,37 +89,37 @@ final class ServiceProvider implements ServiceProviderInterface
      *
      * With this method we make sure that all dependencies used by the static methods are injected as static properties.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return void
      */
-    private function registerDependenciesOnXsltExtension(Application $app)
+    private function registerDependenciesOnXsltExtension(Container $container)
     {
-        Xslt\Extension::$routers = $app['transformer.routing.queue'];
-        Xslt\Extension::$descriptorBuilder = $app['descriptor.builder'];
+        Xslt\Extension::$routers = $container['transformer.routing.queue'];
+        Xslt\Extension::$descriptorBuilder = $container['descriptor.builder'];
     }
 
     /**
      * Returns the Translator service from the Service Locator.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return Translator
      */
-    private function getTranslator(Application $app)
+    private function getTranslator(Container $container)
     {
-        return $app['translator'];
+        return $container['translator'];
     }
 
     /**
      * Returns the WriterCollection service from the Service Locator.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return Collection
      */
-    private function getWriterCollection(Application $app)
+    private function getWriterCollection(Container $container)
     {
-        return $app['transformer.writer.collection'];
+        return $container['transformer.writer.collection'];
     }
 }

--- a/src/phpDocumentor/Plugin/Scrybe/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/Scrybe/ServiceProvider.php
@@ -11,7 +11,6 @@
 
 namespace phpDocumentor\Plugin\Scrybe;
 
-use Cilex\Application;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use phpDocumentor\Plugin\Scrybe\Converter\Definition\Factory;
@@ -72,17 +71,15 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Method responsible for adding the commands for this application.
      *
-     * @param Application|Container $app
+     * @param Container $app
      *
      * @return void
      */
     protected function addCommands(Container $app)
     {
-        if ($app instanceof Application) {
-            $app->command(
-                new Command\Manual\ToHtmlCommand(null, $app[self::TEMPLATE_FACTORY], $app[self::CONVERTER_FACTORY])
-            );
-        }
+        $app['console']->add(
+            new Command\Manual\ToHtmlCommand(null, $app[self::TEMPLATE_FACTORY], $app[self::CONVERTER_FACTORY])
+        );
 
         // FIXME: Disabled the ToLatex and ToPdf commands for now to prevent confusion of users.
         // $this->command(new \phpDocumentor\Plugin\Scrybe\Command\Manual\ToLatexCommand());

--- a/src/phpDocumentor/Transformer/ServiceProvider.php
+++ b/src/phpDocumentor/Transformer/ServiceProvider.php
@@ -184,20 +184,26 @@ class ServiceProvider extends \stdClass implements ServiceProviderInterface
             return $transformer;
         };
 
-        if ($app instanceof Application) {
-            $app->command(new TransformCommand($app['descriptor.builder'], $app['transformer'], $app['compiler']));
-            $app->command(new ListCommand($app['transformer.template.factory']));
-        }
+        $app['console']->add(
+            new TransformCommand(
+                $app['descriptor.builder'],
+                $app['transformer'],
+                $app['compiler'],
+                $app['descriptor.cache'],
+                $app['event_dispatcher']
+            )
+        );
+        $app['console']->add(new ListCommand($app['transformer.template.factory']));
     }
 
     /**
      * Initializes the templating system in the container.
      *
-     * @param Application $app
+     * @param Container $container
      *
      * @return void
      */
-    protected function provideTemplatingSystem(Application $app)
+    protected function provideTemplatingSystem(Container $container)
     {
         $templateDir = __DIR__ . '/../../../data/templates';
 
@@ -208,21 +214,21 @@ class ServiceProvider extends \stdClass implements ServiceProviderInterface
         }
 
         // parameters
-        $app['transformer.template.location'] = $templateDir;
+        $container['transformer.template.location'] = $templateDir;
 
         // services
-        $app['transformer.template.path_resolver'] = function ($container) {
+        $container['transformer.template.path_resolver'] = function ($container) {
             return new PathResolver($container['transformer.template.location']);
         };
 
-        $app['transformer.template.factory'] = function ($container) {
+        $container['transformer.template.factory'] = function ($container) {
             return new Factory(
                 $container['transformer.template.path_resolver'],
                 $container['serializer']
             );
         };
 
-        $app['transformer.template.collection'] = function ($container) {
+        $container['transformer.template.collection'] = function ($container) {
             return new Template\Collection(
                 $container['transformer.template.factory'],
                 $container['transformer.writer.collection']

--- a/tests/unit/phpDocumentor/Parser/Command/Project/ParseCommandTest.php
+++ b/tests/unit/phpDocumentor/Parser/Command/Project/ParseCommandTest.php
@@ -22,8 +22,10 @@ use phpDocumentor\DomainModel\Parser\FileCollector;
 use phpDocumentor\Fileset\Collection;
 use phpDocumentor\Parser\Command\Project\ParseCommand;
 use \Mockery as m;
+use phpDocumentor\Parser\Middleware\CacheMiddleware;
 use phpDocumentor\Parser\Parser;
 use phpDocumentor\Reflection\DocBlock\ExampleFinder;
+use Stash\Pool;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArrayInput;
 use Zend\Cache\Storage\StorageInterface;
@@ -110,7 +112,8 @@ class ParseCommandTest extends MockeryTestCase
             $translator,
             $cache,
             new ExampleFinder(),
-            m::mock(\phpDocumentor\Partials\Collection::class)
+            m::mock(\phpDocumentor\Partials\Collection::class),
+            new CacheMiddleware(m::mock(Pool::class))
         );
 
 

--- a/tests/unit/phpDocumentor/Plugin/Core/ServiceProviderTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/ServiceProviderTest.php
@@ -13,6 +13,7 @@ namespace phpDocumentor\Plugin\Core;
 
 use \Mockery as m;
 use Cilex\Application;
+use Pimple\Container;
 
 /**
  * Tests whether all expected Services for the Core plugin are loaded using the ServiceProvider.
@@ -42,22 +43,22 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $mockCollection        = $this->givenAWriterCollection();
         $mockLogger            = $this->givenALogger();
-        $mockApplication       = $this->givenAnApplication($mockCollection, $mockLogger);
-        $mockRouterQueue       = $this->givenARouterQueue($mockApplication);
-        $mockTranslator        = $this->givenATranslator($mockApplication);
-        $mockDescriptorBuilder = $this->givenAProjectDescriptorBuilder($mockApplication);
+        $mockContainer       = $this->givenAnContainer($mockCollection, $mockLogger);
+        $mockRouterQueue       = $this->givenARouterQueue($mockContainer);
+        $mockTranslator        = $this->givenATranslator($mockContainer);
+        $mockDescriptorBuilder = $this->givenAProjectDescriptorBuilder($mockContainer);
 
         $this->thenATranslationFolderIsAdded($mockTranslator);
 
         $this->thenWritersAreRegistered($mockCollection);
-        $this->thenRouterIsSetOnXmlWriter($mockApplication);
+        $this->thenRouterIsSetOnXmlWriter($mockContainer);
         $this->thenTranslatorIsSetOnWriter('Checkstyle', $mockTranslator, $mockCollection);
         $this->thenTranslatorIsSetOnWriter('Xml', $mockTranslator, $mockCollection);
 
-        $this->thenProviderIsRegistered($mockApplication, 'phpDocumentor\Plugin\Graphs\ServiceProvider');
-        $this->thenProviderIsRegistered($mockApplication, 'phpDocumentor\Plugin\Twig\ServiceProvider');
+        $this->thenProviderIsRegistered($mockContainer, 'phpDocumentor\Plugin\Graphs\ServiceProvider');
+        $this->thenProviderIsRegistered($mockContainer, 'phpDocumentor\Plugin\Twig\ServiceProvider');
 
-        $this->fixture->register($mockApplication);
+        $this->fixture->register($mockContainer);
 
         $this->assertSame($mockRouterQueue, Xslt\Extension::$routers);
         $this->assertSame($mockDescriptorBuilder, Xslt\Extension::$descriptorBuilder);
@@ -68,9 +69,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      *
      * @return m\MockInterface
      */
-    private function givenAnApplication($mockCollection, $mockLogger)
+    private function givenAnContainer($mockCollection, $mockLogger)
     {
-        $mockApplication = m::mock('Cilex\Application');
+        $mockApplication = m::mock(Container::class);
 
         $mockApplication->shouldReceive('offsetGet')
             ->once()

--- a/tests/unit/phpDocumentor/Transformer/ServiceProviderTest.php
+++ b/tests/unit/phpDocumentor/Transformer/ServiceProviderTest.php
@@ -18,6 +18,7 @@ use phpDocumentor\Compiler\Pass\InterfaceTreeBuilder;
 use \phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\ExampleFinder;
+use Zend\Cache\Storage\StorageInterface;
 
 /**
  * Tests for phpDocumentor\Translator\ServiceProvider
@@ -63,6 +64,7 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->application['parser.example.finder'] = $finder;
         $this->application['monolog'] = $logger;
         $this->application['descriptor.analyzer'] = $analyzer;
+        $this->application['descriptor.cache'] = m::mock(StorageInterface::class);
         $this->application['console']->getHelperSet()->set($loggerHelper);
 
         $this->fixture = new ServiceProvider();

--- a/tests/unit/phpDocumentor/Transformer/ServiceProviderTest.php
+++ b/tests/unit/phpDocumentor/Transformer/ServiceProviderTest.php
@@ -12,12 +12,13 @@
 
 namespace phpDocumentor\Transformer;
 
-use Cilex\Application;
 use phpDocumentor\Compiler\Pass\ClassTreeBuilder;
 use phpDocumentor\Compiler\Pass\InterfaceTreeBuilder;
-use \phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\ExampleFinder;
+use Pimple\Container;
+use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Zend\Cache\Storage\StorageInterface;
 
 /**
@@ -30,15 +31,15 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     /** @var ServiceProvider $fixture */
     protected $fixture;
 
-    /** @var Application $application */
-    protected $application;
+    /** @var Container $container */
+    protected $container;
 
     /**
      * Setup test fixture and mocks used in this TestCase
      */
     protected function setUp()
     {
-        $this->application = new Application('test');
+        $this->container = new Container();
 
         $projectDescriptorBuilder = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
         $serializer = m::mock('JMS\Serializer\Serializer');
@@ -58,14 +59,16 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $loggerHelper->shouldReceive('setHelperSet');
         $loggerHelper->shouldReceive('addOptions');
 
-        $this->application['descriptor.builder'] = $projectDescriptorBuilder;
-        $this->application['serializer'] = $serializer;
-        $this->application['config'] = $configuration;
-        $this->application['parser.example.finder'] = $finder;
-        $this->application['monolog'] = $logger;
-        $this->application['descriptor.analyzer'] = $analyzer;
-        $this->application['descriptor.cache'] = m::mock(StorageInterface::class);
-        $this->application['console']->getHelperSet()->set($loggerHelper);
+        $this->container['descriptor.builder'] = $projectDescriptorBuilder;
+        $this->container['serializer'] = $serializer;
+        $this->container['config'] = $configuration;
+        $this->container['parser.example.finder'] = $finder;
+        $this->container['monolog'] = $logger;
+        $this->container['descriptor.analyzer'] = $analyzer;
+        $this->container['descriptor.cache'] = m::mock(StorageInterface::class);
+        $this->container['console'] = new ConsoleApplication();
+        $this->container['event_dispatcher'] = new EventDispatcher();
+        $this->container['console']->getHelperSet()->set($loggerHelper);
 
         $this->fixture = new ServiceProvider();
     }
@@ -75,9 +78,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterSetsLinkerSubstitutions()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $substitutions = $this->application['linker.substitutions'];
+        $substitutions = $this->container['linker.substitutions'];
         $this->assertSame($substitutions, $this->givenLinkerSubstitutions());
     }
 
@@ -86,9 +89,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterSetsCompiler()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $compiler = $this->application->offsetGet('compiler');
+        $compiler = $this->container->offsetGet('compiler');
 
         $this->assertInstanceOf('phpDocumentor\Compiler\Compiler', $compiler);
         $this->assertCount(11, $compiler);
@@ -120,9 +123,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterSetsLinker()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $linker = $this->application->offsetGet('linker');
+        $linker = $this->container->offsetGet('linker');
 
         $this->assertInstanceOf('phpDocumentor\Compiler\Linker\Linker', $linker);
         $this->assertSame($this->givenLinkerSubstitutions(), $linker->getSubstitutions());
@@ -133,9 +136,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTransformerBehaviourCollection()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $collection = $this->application->offsetGet('transformer.behaviour.collection');
+        $collection = $this->container->offsetGet('transformer.behaviour.collection');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Behaviour\Collection', $collection);
     }
@@ -145,9 +148,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTransformerRoutingStandard()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $router = $this->application->offsetGet('transformer.routing.standard');
+        $router = $this->container->offsetGet('transformer.routing.standard');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Router\StandardRouter', $router);
     }
@@ -157,9 +160,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTransformerRoutingExternal()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $router = $this->application->offsetGet('transformer.routing.external');
+        $router = $this->container->offsetGet('transformer.routing.external');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Router\ExternalRouter', $router);
     }
@@ -169,14 +172,14 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTransformerRoutingQueue()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $queue = $this->application->offsetGet('transformer.routing.queue');
+        $queue = $this->container->offsetGet('transformer.routing.queue');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Router\Queue', $queue);
-        $this->assertSame($this->application->offsetGet('transformer.routing.external'), $queue->current());
+        $this->assertSame($this->container->offsetGet('transformer.routing.external'), $queue->current());
         $queue->next();
-        $this->assertSame($this->application->offsetGet('transformer.routing.standard'), $queue->current());
+        $this->assertSame($this->container->offsetGet('transformer.routing.standard'), $queue->current());
     }
 
     /**
@@ -184,9 +187,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTransformerWriterCollection()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $collection = $this->application->offsetGet('transformer.writer.collection');
+        $collection = $this->container->offsetGet('transformer.writer.collection');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Writer\Collection', $collection);
     }
@@ -196,9 +199,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTemplateLocation()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $location = $this->application->offsetGet('transformer.template.location');
+        $location = $this->container->offsetGet('transformer.template.location');
 
         $this->assertSame('templates', substr($location, -9));
     }
@@ -208,9 +211,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTemplatePathResolver()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $resolver = $this->application->offsetGet('transformer.template.path_resolver');
+        $resolver = $this->container->offsetGet('transformer.template.path_resolver');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Template\PathResolver', $resolver);
         $this->assertSame('templates', substr($resolver->getTemplatePath(), -9));
@@ -221,9 +224,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTemplateFactory()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $factory = $this->application->offsetGet('transformer.template.factory');
+        $factory = $this->container->offsetGet('transformer.template.factory');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Template\Factory', $factory);
     }
@@ -233,9 +236,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTemplateCollection()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $collection = $this->application->offsetGet('transformer.template.collection');
+        $collection = $this->container->offsetGet('transformer.template.collection');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Template\Collection', $collection);
     }
@@ -245,9 +248,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTransformer()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $transformer = $this->application->offsetGet('transformer');
+        $transformer = $this->container->offsetGet('transformer');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Transformer', $transformer);
     }
@@ -257,9 +260,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterTransformCommand()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $transformCommand = $this->application->offsetGet('console')->get('transform');
+        $transformCommand = $this->container->offsetGet('console')->get('transform');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Command\Project\TransformCommand', $transformCommand);
     }
@@ -269,9 +272,9 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterListCommand()
     {
-        $this->fixture->register($this->application);
+        $this->fixture->register($this->container);
 
-        $listCommand = $this->application->offsetGet('console')->get('template:list');
+        $listCommand = $this->container->offsetGet('console')->get('template:list');
 
         $this->assertInstanceOf('phpDocumentor\Transformer\Command\Template\ListCommand', $listCommand);
     }
@@ -283,7 +286,7 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterThrowsExceptionIfBuilderIsMissing()
     {
-        $this->fixture->register(new Application('test'));
+        $this->fixture->register(new Container());
     }
 
     /**
@@ -293,11 +296,11 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterThrowsExceptionIfSerializerIsMissing()
     {
-        $application = new Application('test');
+        $container = new Container();
         $projectDescriptorBuilder = m::mock('phpDocumentor\Descriptor\ProjectDescriptorBuilder');
-        $application['descriptor.builder'] = $projectDescriptorBuilder;
+        $container['descriptor.builder'] = $projectDescriptorBuilder;
 
-        $this->fixture->register($application);
+        $this->fixture->register($container);
     }
 
     private function givenLinkerSubstitutions()

--- a/tests/unit/phpDocumentor/Translator/ServiceProviderTest.php
+++ b/tests/unit/phpDocumentor/Translator/ServiceProviderTest.php
@@ -13,6 +13,7 @@ namespace phpDocumentor\Translator;
 
 use Cilex\Application;
 use Mockery as m;
+use Pimple\Container;
 
 /**
  * Tests for phpDocumentor\Translator\ServiceProvider
@@ -29,18 +30,18 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     /** @var ServiceProvider $fixture */
     protected $fixture = null;
 
-    /** @var Application $application */
-    protected $application = null;
+    /** @var Container $container */
+    protected $container = null;
 
     /**
      * Setup test fixture and mocks used in this TestCase
      */
     protected function setUp()
     {
-        $this->application = new Application('test');
-        $this->application['config'] = m::mock('phpDocumentor\Configuration');
+        $this->container = new Container();
+        $this->container['config'] = m::mock('phpDocumentor\Configuration');
 
-        $this->application['config']->shouldReceive('getTranslator->getLocale')
+        $this->container['config']->shouldReceive('getTranslator->getLocale')
         ->andReturn($this->locale);
         $this->fixture = new ServiceProvider();
     }
@@ -50,11 +51,11 @@ class ServiceProviderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testRegisterSetsTranslator()
     {
-        $this->fixture->register($this->application);
-        $translator = $this->application['translator'];
+        $this->fixture->register($this->container);
+        $translator = $this->container['translator'];
 
-        $this->assertSame($this->locale, $this->application['translator.locale']);
+        $this->assertSame($this->locale, $this->container['translator.locale']);
         $this->assertInstanceOf('phpDocumentor\Translator\Translator', $translator);
-        $this->assertSame($this->application['translator.locale'], $translator->getLocale());
+        $this->assertSame($this->container['translator.locale'], $translator->getLocale());
     }
 }


### PR DESCRIPTION
Cilex is blocking the updates of symfony components. This
pr removes a lot of magic from the commands which were fetching dependencies
form the application.
The application is updated with some logic to access the inner container to support
the old behavior of the application like cilex provides. This needs to be removed
in the future.