### PR TITLE
Add unit tests for the Descriptor namespace

### DIFF
--- a/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
@@ -75,6 +75,7 @@ class ArgumentDescriptor extends DescriptorAbstract implements Interfaces\Argume
                 }
             }
         }
+
         return null;
     }
 

--- a/src/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapperTest.php
+++ b/src/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapperTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace phpDocumentor\Descriptor\Cache;
+
+use phpDocumentor\Descriptor\ProjectDescriptor;
+use PHPUnit\Framework\TestCase;
+use Zend\Cache\Storage\Adapter\Memory;
+use Zend\Cache\Storage\StorageInterface;
+use Mockery as m;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Descriptor\Cache\ProjectDescriptorMapper
+ * @covers ::__construct
+ */
+final class ProjectDescriptorMapperTest extends TestCase
+{
+    /** @var ProjectDescriptorMapper */
+    private $mapper;
+
+    /** @var StorageInterface */
+    private $cacheDriver;
+
+    public function setUp()
+    {
+        $this->cacheDriver = new Memory();
+        $this->mapper = new ProjectDescriptorMapper($this->cacheDriver);
+    }
+
+    /**
+     * @covers ::getCache
+     */
+    public function testThatTheCacheDriverCanBeRetrieved()
+    {
+        $this->assertSame($this->cacheDriver, $this->mapper->getCache());
+    }
+
+    /**
+     * @covers ::getCache
+     */
+    public function testThatACacheDriverMustBeAZendStorageInterface()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->mapper = new ProjectDescriptorMapper(m::mock(StorageInterface::class));
+    }
+
+    /**
+     * @covers ::save
+     * @covers ::populate
+     */
+    public function testThatATheSettingsForAProjectDescriptorArePersistedAndCanBeRetrievedFromCache()
+    {
+        $projectDescriptor = new ProjectDescriptor('project');
+
+        $this->assertFalse($projectDescriptor->getSettings()->shouldIncludeSource());
+        $projectDescriptor->getSettings()->includeSource();
+        $this->assertTrue($projectDescriptor->getSettings()->shouldIncludeSource());
+
+        $this->mapper->save($projectDescriptor);
+
+        $restoredProjectDescriptor = new ProjectDescriptor('project2');
+        $this->mapper->populate($restoredProjectDescriptor);
+
+        $this->assertTrue($restoredProjectDescriptor->getSettings()->shouldIncludeSource());
+    }
+}

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTagsTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTagsTest.php
@@ -110,48 +110,6 @@ class ResolveInlineLinkAndSeeTagsTest extends \Mockery\Adapter\Phpunit\MockeryTe
     /**
      * @covers ::execute
      */
-    public function testReplaceDescriptionIfItContainsALinkAndFileIsPresent()
-    {
-        $this->markTestSkipped('Needs rewrite');
-        $description = 'Description with {@link LinkDescriptor}';
-        $expected =
-            'Description with [LinkDescriptor](../classes/phpDocumentor.LinkDescriptor.html)';
-
-        $descriptor = $this->givenAChildDescriptorWithDescription($description);
-        $collection = $this->givenACollection($descriptor);
-        $elementToLinkTo = $this->givenAnElementToLinkTo();
-
-        $this->whenDescriptionContainsSeeOrLinkWithElement($descriptor, $elementToLinkTo);
-
-        $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $expected);
-
-        $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
-
-        $this->fixture->execute($project);
-    }
-
-    /**
-     * @covers ::execute
-     */
-    public function testReplaceDescriptionIfItContainsAUrl()
-    {
-        $this->markTestSkipped('Needs rewrite');
-        $description = 'Description with {@see http://www.phpdoc.org}';
-        $expected = 'Description with [http://www.phpdoc.org](http://www.phpdoc.org)';
-
-        $descriptor = $this->givenAChildDescriptorWithDescription($description);
-        $collection = $this->givenACollection($descriptor);
-
-        $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $expected);
-
-        $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
-
-        $this->fixture->execute($project);
-    }
-
-    /**
-     * @covers ::execute
-     */
     public function testReplaceDescriptionIfItContainsAnotherTag()
     {
         $description = 'Description with {@author John Doe}';

--- a/tests/unit/phpDocumentor/Descriptor/ArgumentDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ArgumentDescriptorTest.php
@@ -12,7 +12,7 @@
 namespace phpDocumentor\Descriptor;
 
 /**
- * Tests the functionality for the ArgumentDescriptor class.
+ * @coversDefaultClass \phpDocumentor\Descriptor\ArgumentDescriptor
  */
 class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 {
@@ -20,7 +20,7 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     protected $fixture;
 
     /**
-     * Creates a new (emoty) fixture object.
+     * Creates a new (empty) fixture object.
      */
     protected function setUp()
     {
@@ -28,8 +28,8 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::getTypes
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::setTypes
+     * @covers ::getTypes
+     * @covers ::setTypes
      */
     public function testSetAndGetTypes()
     {
@@ -41,8 +41,8 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::getDefault
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::setDefault
+     * @covers ::getDefault
+     * @covers ::setDefault
      */
     public function testSetAndGetDefault()
     {
@@ -54,8 +54,8 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::isByReference
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::setByReference
+     * @covers ::isByReference
+     * @covers ::setByReference
      */
     public function testSetAndGetWhetherArgumentIsPassedByReference()
     {
@@ -66,8 +66,22 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertTrue($this->fixture->isByReference());
     }
 
+
     /**
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::getDescription
+     * @covers ::isVariadic
+     * @covers ::setVariadic
+     */
+    public function testSetAndGetWhetherArgumentIsAVariadic()
+    {
+        $this->assertFalse($this->fixture->isVariadic());
+
+        $this->fixture->setVariadic(true);
+
+        $this->assertTrue($this->fixture->isVariadic());
+    }
+
+    /**
+     * @covers ::getDescription
      */
     public function testDescriptionInheritsWhenNoneIsPresent()
     {
@@ -84,7 +98,7 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::getDescription
+     * @covers ::getDescription
      */
     public function testDescriptionIsNotInheritedWhenPresent()
     {
@@ -101,7 +115,7 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * @covers phpDocumentor\Descriptor\ArgumentDescriptor::getTypes
+     * @covers ::getTypes
      */
     public function testTypeIsInheritedWhenNoneIsPresent()
     {
@@ -117,12 +131,31 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame($types, $result);
     }
 
+
     /**
-     * @param string $argumentName The name of the current method.
-     *
-     * @return ArgumentDescriptor
+     * @covers ::setMethod
+     * @covers ::getInheritedElement
      */
-    private function whenFixtureHasMethodAndArgumentInParentClassWithSameName($argumentName)
+    public function testGetTheArgumentFromWhichThisArgumentInherits()
+    {
+        $this->assertNull(
+            $this->fixture->getInheritedElement(),
+            'By default, an argument does not have an inherited element'
+        );
+
+        $method = new MethodDescriptor;
+        $method->setName('same');
+        $method->addArgument('abc', $this->fixture);
+        $this->fixture->setMethod($method);
+
+        $this->assertNull($this->fixture->getInheritedElement());
+
+        $this->whenFixtureHasMethodAndArgumentInParentClassWithSameName('abcd');
+
+        $this->assertNotNull($this->fixture->getInheritedElement());
+    }
+
+    private function whenFixtureHasMethodAndArgumentInParentClassWithSameName(string $argumentName): ArgumentDescriptor
     {
         $this->fixture->setName($argumentName);
 
@@ -136,6 +169,7 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $method = new MethodDescriptor;
         $method->setName('same');
         $method->addArgument($argumentName, $this->fixture);
+        $this->fixture->setMethod($method);
 
         $parent = new ClassDescriptor();
         $parent->getMethods()->set('same', $parentMethod);
@@ -147,6 +181,5 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $method->setParent($class);
 
         return $parentArgument;
-
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/FunctionDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/FunctionDescriptorTest.php
@@ -12,9 +12,10 @@
 namespace phpDocumentor\Descriptor;
 
 use \Mockery as m;
+use phpDocumentor\Reflection\Types\String_;
 
 /**
- * Tests the functionality for the FunctionDescriptor class.
+ * @coversDefaultClass \phpDocumentor\Descriptor\FunctionDescriptor
  */
 class FunctionDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 {
@@ -30,9 +31,7 @@ class FunctionDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * Tests whether all collection objects are properly initialized.
-     *
-     * @covers phpDocumentor\Descriptor\FunctionDescriptor::__construct
+     * @covers ::__construct
      */
     public function testInitialize()
     {
@@ -40,8 +39,8 @@ class FunctionDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * @covers phpDocumentor\Descriptor\FunctionDescriptor::setArguments
-     * @covers phpDocumentor\Descriptor\FunctionDescriptor::getArguments
+     * @covers ::setArguments
+     * @covers ::getArguments
      */
     public function testSettingAndGettingArguments()
     {
@@ -53,5 +52,18 @@ class FunctionDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->fixture->setArguments($mock);
 
         $this->assertSame($mockInstance, $this->fixture->getArguments());
+    }
+
+    /**
+     * @covers ::getResponse
+     * @covers ::setReturnType
+     */
+    public function testSettingAndGettingReturnType()
+    {
+        $stringType = new String_();
+        $this->fixture->setReturnType($stringType);
+
+        $this->assertSame('return', $this->fixture->getResponse()->getName());
+        $this->assertSame($stringType, $this->fixture->getResponse()->getTypes());
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorBuilderTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorBuilderTest.php
@@ -41,37 +41,6 @@ class ProjectDescriptorBuilderTest extends \Mockery\Adapter\Phpunit\MockeryTestC
     }
 
     /**
-     * Demonstrates the basic usage the the ProjectDescriptorBuilder.
-     *
-     * This test scenario demonstrates how a ProjectDescriptorBuilder can be used to create a new ProjectDescriptor
-     * and populate it with a single FileDescriptor using a FileReflector as source.
-     *
-     * @covers phpDocumentor\Descriptor\ProjectDescriptorBuilder::createProjectDescriptor
-     * @covers phpDocumentor\Descriptor\ProjectDescriptorBuilder::buildFileUsingSourceData
-     * @covers phpDocumentor\Descriptor\ProjectDescriptorBuilder::getProjectDescriptor
-     *
-     * @see self::setUp on how to create an instance of the builder.
-     *
-     * @return void
-     */
-    public function testCreateNewProjectDescriptorAndBuildFile()
-    {
-        $this->markTestIncomplete('Finish later, in a hurry now.');
-        // we use a FileReflector as example input
-        $data = $this->createFileReflectorMock();
-
-        $this->createFileDescriptorCreationMock();
-
-        // usage example, see the setup how to instantiate the builder.
-        $this->fixture->createProjectDescriptor();
-        $projectDescriptor = $this->fixture->getProjectDescriptor();
-
-        // assert functioning
-        $this->assertInstanceOf('phpDocumentor\Descriptor\ProjectDescriptor', $projectDescriptor);
-        $this->assertCount(1, $projectDescriptor->getFiles());
-    }
-
-    /**
      * @covers phpDocumentor\Descriptor\ProjectDescriptorBuilder::createProjectDescriptor
      * @covers phpDocumentor\Descriptor\ProjectDescriptorBuilder::getProjectDescriptor
      */

--- a/tests/unit/phpDocumentor/Plugin/Scrybe/Converter/RestructuredText/Visitors/DiscoverTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Scrybe/Converter/RestructuredText/Visitors/DiscoverTest.php
@@ -87,12 +87,6 @@ class DiscoverTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         );
     }
 
-    public function testRetrieveFilename()
-    {
-        $this->markTestIncomplete("testRetrieveFilename() is not working...");
-        //$this->assertSame(self::FILENAME, $this->object->getFilename());
-    }
-
     public function testRetrieveDocument()
     {
         $this->assertSame(

--- a/tests/unit/phpDocumentor/Plugin/Scrybe/Template/FactoryTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Scrybe/Template/FactoryTest.php
@@ -37,21 +37,6 @@ class FactoryTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * Tests whether this factory registers the twig template engine by default.
-     *
-     * @covers \phpDocumentor\Plugin\Scrybe\Template\Factory
-     */
-    public function testHasTwigTemplateEngine()
-    {
-        $this->markTestSkipped('Invalid test case?');
-        $factory = new Factory();
-        $this->assertInstanceOf(
-            '\phpDocumentor\Plugin\Scrybe\Template\Twig',
-            $factory->get('twig')
-        );
-    }
-
-    /**
      * Tests whether a Template could be registered using the register method.
      *
      * @covers \phpDocumentor\Plugin\Scrybe\Template\Factory::register


### PR DESCRIPTION
In this commit I have also performed a few cleanups in the descriptor classes.
This can mean that other parts of the code have been touched as well.

TODO:

- [ ] Add more tests for the ProjectDescriptorBuilder
- [ ] Add tests in child classes for all Abstract base classes (where missing)
- [ ] Add tests for the incomplete test cases for all Descriptors
- [ ] Add tests for the ProjectDescriptor
- [ ] Add tests for the Cache namespace
- [ ] Add tests for the Builder namespace