### PR TITLE
Adds marker tests

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -157,6 +157,7 @@ services:
             - [insert, ['@phpDocumentor\Compiler\Pass\ClassTreeBuilder', !php/const \phpDocumentor\Compiler\Pass\ClassTreeBuilder::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Compiler\Pass\InterfaceTreeBuilder', !php/const \phpDocumentor\Compiler\Pass\InterfaceTreeBuilder::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Compiler\Pass\ResolveInlineLinkAndSeeTags', !php/const \phpDocumentor\Compiler\Pass\ResolveInlineLinkAndSeeTags::COMPILER_PRIORITY]]
+            - [insert, ['@phpDocumentor\Compiler\Pass\ResolveInlineMarkers', !php/const \phpDocumentor\Compiler\Pass\ResolveInlineMarkers::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Compiler\Pass\Debug', !php/const \phpDocumentor\Compiler\Pass\Debug::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Compiler\Linker\Linker', !php/const \phpDocumentor\Compiler\Linker\Linker::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Transformer\Transformer', !php/const \phpDocumentor\Transformer\Transformer::COMPILER_PRIORITY]]

--- a/src/phpDocumentor/Application/Stage/Parser.php
+++ b/src/phpDocumentor/Application/Stage/Parser.php
@@ -139,6 +139,7 @@ final class Parser
         $visibility = $this->getVisibility($apiConfig);
         $projectDescriptor->getSettings()->setVisibility($visibility);
         $projectDescriptor->getSettings()->setMarkers($apiConfig['markers']);
+        $projectDescriptor->getSettings()->includeSource();
 
         $mapper = new ProjectDescriptorMapper($this->getCache());
 

--- a/src/phpDocumentor/Application/Stage/Parser.php
+++ b/src/phpDocumentor/Application/Stage/Parser.php
@@ -138,6 +138,7 @@ final class Parser
 
         $visibility = $this->getVisibility($apiConfig);
         $projectDescriptor->getSettings()->setVisibility($visibility);
+        $projectDescriptor->getSettings()->setMarkers($apiConfig['markers']);
 
         $mapper = new ProjectDescriptorMapper($this->getCache());
 

--- a/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
+++ b/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ *  This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ * @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ *
+ */
+
+namespace phpDocumentor\Compiler\Pass;
+
+use phpDocumentor\Compiler\CompilerPassInterface;
+use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\ProjectDescriptor;
+
+final class ResolveInlineMarkers implements CompilerPassInterface
+{
+    const COMPILER_PRIORITY = 9000;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDescription()
+    {
+        return 'Collect all markers in a file';
+    }
+
+    /**
+     * Scans the files for markers and records them in the markers property of a file.
+     *
+     * @return void
+     */
+    public function execute(ProjectDescriptor $project): void
+    {
+        $markerTerms = $project->getSettings()->getMarkers();
+
+        foreach ($project->getFiles() as $file) {
+
+            $marker_data = [];
+            $matches = [];
+            preg_match_all(
+                '~//[\s]*(' . implode('|', $markerTerms) . ')\:?[\s]*(.*)~',
+                $file->getSource(),
+                $matches,
+                PREG_SET_ORDER | PREG_OFFSET_CAPTURE
+            );
+
+            foreach ($matches as $match) {
+                list($before) = str_split($file->getSource(), $match[1][1]); // fetches all the text before the match
+
+                $line_number = strlen($before) - strlen(str_replace("\n", "", $before)) + 1;
+
+                $marker_data[] = ['type' => trim($match[1][0], '@'), 'line' => $line_number, $match[2][0]];
+            }
+
+            $file->setMarkers(new Collection($marker_data));
+        }
+    }
+}

--- a/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
+++ b/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
@@ -8,7 +8,6 @@
  * @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
- *
  */
 
 namespace phpDocumentor\Compiler\Pass;
@@ -24,22 +23,19 @@ final class ResolveInlineMarkers implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return 'Collect all markers in a file';
     }
 
     /**
      * Scans the files for markers and records them in the markers property of a file.
-     *
-     * @return void
      */
     public function execute(ProjectDescriptor $project): void
     {
         $markerTerms = $project->getSettings()->getMarkers();
 
         foreach ($project->getFiles() as $file) {
-
             $marker_data = [];
             $matches = [];
             preg_match_all(
@@ -52,7 +48,7 @@ final class ResolveInlineMarkers implements CompilerPassInterface
             foreach ($matches as $match) {
                 list($before) = str_split($file->getSource(), $match[1][1]); // fetches all the text before the match
 
-                $line_number = strlen($before) - strlen(str_replace("\n", "", $before)) + 1;
+                $line_number = strlen($before) - strlen(str_replace("\n", '', $before)) + 1;
 
                 $marker_data[] = ['type' => trim($match[1][0], '@'), 'line' => $line_number, $match[2][0]];
             }

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor/Settings.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor/Settings.php
@@ -40,6 +40,8 @@ class Settings
     /** @var bool */
     protected $includeSource = false;
 
+    private $markers;
+
     /**
      * Stores the visibilities that are allowed to be executed as a bitflag.
      *
@@ -105,5 +107,15 @@ class Settings
     public function shouldIncludeSource()
     {
         return $this->includeSource;
+    }
+
+    public function setMarkers(array $markers)
+    {
+        $this->markers = $markers;
+    }
+
+    public function getMarkers()
+    {
+        return $this->markers;
     }
 }

--- a/tests/features/assets/singlefile/markers.php
+++ b/tests/features/assets/singlefile/markers.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ */
+
+class Markers
+{
+    //TODO: implement this class
+}

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -13,7 +13,6 @@
 namespace phpDocumentor\Behat\Contexts\Ast;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
 use phpDocumentor\Descriptor\ArgumentDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
@@ -551,6 +550,6 @@ class ApiContext extends BaseContext implements Context
         /** @var FileDescriptor $file */
         $file = $ast->getFiles()->get($filename);
 
-        Assert::assertCount(1, $file->getMarkers());
+        Assert::count($file->getMarkers(), 1);
     }
 }

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -13,6 +13,7 @@
 namespace phpDocumentor\Behat\Contexts\Ast;
 
 use Behat\Behat\Context\Context;
+use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
 use phpDocumentor\Descriptor\ArgumentDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
@@ -538,5 +539,18 @@ class ApiContext extends BaseContext implements Context
         }
 
         return null;
+    }
+
+    /**
+     * @Then /^file "([^"]*)" must contain a marker$/
+     */
+    public function fileMustContainAMarker($filename)
+    {
+        $ast = $this->getAst();
+
+        /** @var FileDescriptor $file */
+        $file = $ast->getFiles()->get($filename);
+
+        Assert::assertCount(1, $file->getMarkers());
     }
 }

--- a/tests/features/core/tags/markers.feature
+++ b/tests/features/core/tags/markers.feature
@@ -1,0 +1,9 @@
+Feature: Todo markers in files
+  In order to add work in progress code
+  As a user
+  I want to be able to add markers in my code to mark todo lines
+
+  Scenario: add TODO in code
+    Given A single file named "test.php" based on "markers.php"
+    When I run "phpdoc -f test.php"
+    Then file "test.php" must contain a marker

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
@@ -8,11 +8,9 @@
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
  *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      http://phpdoc.org
- *
  */
 
 namespace phpDocumentor\Compiler\Pass;
-
 
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\FileDescriptor;
@@ -42,6 +40,6 @@ SOURCE
 
         $fixture->execute($projectDescriptor);
 
-        self::assertCount(1,$fileDescriptor->getMarkers());
+        self::assertCount(1, $fileDescriptor->getMarkers());
     }
 }

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *  This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ *
+ */
+
+namespace phpDocumentor\Compiler\Pass;
+
+
+use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\FileDescriptor;
+use phpDocumentor\Descriptor\ProjectDescriptor;
+
+final class ResolveInlineMarkersTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
+{
+    public function testExecuteSetsMarkers()
+    {
+        $fixture = new ResolveInlineMarkers();
+
+        $fileDescriptor = new FileDescriptor('abc');
+        $fileDescriptor->setSource(
+            <<<SOURCE
+                <?php
+                
+                class Marker
+                {
+                   //TODO: implement this
+                }      
+SOURCE
+);
+
+        $projectDescriptor = new ProjectDescriptor('test project');
+        $projectDescriptor->getSettings()->setMarkers(['TODO']);
+        $projectDescriptor->setFiles(new Collection([$fileDescriptor]));
+
+        $fixture->execute($projectDescriptor);
+
+        self::assertCount(1,$fileDescriptor->getMarkers());
+    }
+}


### PR DESCRIPTION
Our previous reflection component was able to find markers in the source code.
We removed this behaviour during refactoring to focus on reflecting the source tree and
not it's contents.
After some benchmarking I found that this would be the most suitable way of implementing the
marker feature in phpdocumentor it self.

fixes #1956