### PR TITLE
Fixes an issue in cache dir handling

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -76,12 +76,17 @@ services:
     phpdoc.command.run.pipeline:
       class: 'League\Pipeline\Pipeline'
       factory: ['phpDocumentor\Application\PipelineFactory', create]
-      arguments: ['@phpdoc.application.pipeline', '@phpDocumentor\Application\Stage\Parser', '@phpDocumentor\Application\Stage\Transform']
+      arguments: ['@phpdoc.application.pipeline', '@phpdoc.parse.pipeline.internal', '@phpDocumentor\Application\Stage\Transform']
 
     phpdoc.command.parse.pipeline:
       class: 'League\Pipeline\Pipeline'
       factory: ['phpDocumentor\Application\PipelineFactory', create]
-      arguments: ['@phpdoc.application.pipeline', '@phpDocumentor\Application\Stage\Parser']
+      arguments: ['@phpdoc.application.pipeline', '@phpdoc.parse.pipeline.internal']
+
+    phpdoc.parse.pipeline.internal:
+      class: 'League\Pipeline\Pipeline'
+      factory: ['phpDocumentor\Application\PipelineFactory', create]
+      arguments: ['@phpDocumentor\Application\Stage\Parser\ConfigureCache', '@phpDocumentor\Application\Stage\Parser']
 
     phpdoc.command.transform.pipeline:
       class: 'League\Pipeline\Pipeline'

--- a/src/phpDocumentor/Application/Stage/Parser.php
+++ b/src/phpDocumentor/Application/Stage/Parser.php
@@ -22,7 +22,6 @@ use phpDocumentor\Partials\Collection as PartialsCollection;
 use phpDocumentor\Reflection\DocBlock\ExampleFinder;
 use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Zend\Cache\Storage\StorageInterface;
 
 /**

--- a/src/phpDocumentor/Application/Stage/Parser.php
+++ b/src/phpDocumentor/Application/Stage/Parser.php
@@ -112,27 +112,12 @@ final class Parser
      */
     public function __invoke(array $configuration)
     {
-        $target = $configuration['phpdocumentor']['paths']['cache'];
-
         //Grep only the first version for now. Multi version support will be added later
         $version = current($configuration['phpdocumentor']['versions']);
 
         //We are currently in the parser stage so grep the api config.
         //And for now we support a single api definition. Could be more in the future.
         $apiConfig = $version['api'][0];
-
-        //Process cache setup
-        $fileSystem = new Filesystem();
-        if (!$fileSystem->isAbsolutePath($target)) {
-            $target = getcwd() . DIRECTORY_SEPARATOR . $target;
-        }
-        if (!file_exists($target)) {
-            if (!mkdir($target) && !is_dir($target)) {
-                throw new \RuntimeException('PPCPP:EXC-BADTARGET');
-            }
-        }
-
-        $this->getCache()->getOptions()->setCacheDir($target);
 
         $parser = $this->getParser();
         $parser->setForced(!$configuration['phpdocumentor']['use-cache']);
@@ -174,7 +159,7 @@ final class Parser
 
         $parser->parse($builder, $files);
 
-        $this->log('PPCPP:LOG-STORECACHE', LogLevel::INFO, ['cacheDir' => $target]);
+        $this->log('PPCPP:LOG-STORECACHE', LogLevel::INFO, ['cacheDir' => $this->getCache()->getOptions()->getCacheDir()]);
         $projectDescriptor->getSettings()->clearModifiedFlag();
         $mapper->save($projectDescriptor);
         $this->log('PPCPP:LOG-OK');

--- a/src/phpDocumentor/Application/Stage/Parser.php
+++ b/src/phpDocumentor/Application/Stage/Parser.php
@@ -158,7 +158,7 @@ final class Parser
 
         $parser->parse($builder, $files);
 
-        $this->log('PPCPP:LOG-STORECACHE', LogLevel::INFO, ['cacheDir' => $this->getCache()->getOptions()->getCacheDir()]);
+        $this->log('PPCPP:LOG-STORECACHE', LogLevel::INFO);
         $projectDescriptor->getSettings()->clearModifiedFlag();
         $mapper->save($projectDescriptor);
         $this->log('PPCPP:LOG-OK');

--- a/src/phpDocumentor/Application/Stage/Parser/ConfigureCache.php
+++ b/src/phpDocumentor/Application/Stage/Parser/ConfigureCache.php
@@ -43,7 +43,7 @@ final class ConfigureCache
             $target = getcwd() . DIRECTORY_SEPARATOR . $target;
         }
         if (!file_exists($target)) {
-            if (!mkdir($target, 0644, true) && !is_dir($target)) {
+            if (!mkdir($target, 0755, true) && !is_dir($target)) {
                 throw new \RuntimeException('PPCPP:EXC-BADTARGET');
             }
         }

--- a/src/phpDocumentor/Application/Stage/Parser/ConfigureCache.php
+++ b/src/phpDocumentor/Application/Stage/Parser/ConfigureCache.php
@@ -8,7 +8,6 @@
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
  *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      http://phpdoc.org
- *
  */
 
 namespace phpDocumentor\Application\Stage\Parser;
@@ -40,16 +39,16 @@ final class ConfigureCache
 
         //Process cache setup
         $fileSystem = new Filesystem();
-        if (!$fileSystem->isAbsolutePath((string)$target)) {
+        if (!$fileSystem->isAbsolutePath((string) $target)) {
             $target = getcwd() . DIRECTORY_SEPARATOR . $target;
         }
         if (!file_exists($target)) {
-            if (!mkdir($target) && !is_dir($target)) {
+            if (!mkdir($target, 0644, true) && !is_dir($target)) {
                 throw new \RuntimeException('PPCPP:EXC-BADTARGET');
             }
         }
 
-        $this->cache->getOptions()->setCacheDir((string)$target);
+        $this->cache->getOptions()->setCacheDir((string) $target);
 
         return $configuration;
     }

--- a/src/phpDocumentor/Application/Stage/Parser/ConfigureCache.php
+++ b/src/phpDocumentor/Application/Stage/Parser/ConfigureCache.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ *  This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ *
+ */
+
+namespace phpDocumentor\Application\Stage\Parser;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Zend\Cache\Storage\StorageInterface;
+
+final class ConfigureCache
+{
+    /**
+     * @var StorageInterface
+     */
+    private $cache;
+
+    public function __construct(StorageInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Executes the business logic involved with this command.
+     *
+     * @return array
+     * @throws \Exception if the target location is not a folder.
+     */
+    public function __invoke(array $configuration)
+    {
+        $target = $configuration['phpdocumentor']['paths']['cache'];
+
+        //Process cache setup
+        $fileSystem = new Filesystem();
+        if (!$fileSystem->isAbsolutePath((string)$target)) {
+            $target = getcwd() . DIRECTORY_SEPARATOR . $target;
+        }
+        if (!file_exists($target)) {
+            if (!mkdir($target) && !is_dir($target)) {
+                throw new \RuntimeException('PPCPP:EXC-BADTARGET');
+            }
+        }
+
+        $this->cache->getOptions()->setCacheDir((string)$target);
+
+        return $configuration;
+    }
+}

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -144,7 +144,6 @@ class ApiContext extends BaseContext implements Context
         }
 
         $element = $class-> {$method}()->get($elementName);
-
         $method = 'get' . $docElement;
         $actual = $element->{$method}();
 

--- a/tests/unit/phpDocumentor/Application/Configuration/CommandlineOptionsMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Application/Configuration/CommandlineOptionsMiddlewareTest.php
@@ -119,5 +119,4 @@ final class CommandlineOptionsMiddlewareTest extends MockeryTestCase
             current($newConfiguration['phpdocumentor']['versions'])['api'][0]['source']
         );
     }
-
 }

--- a/tests/unit/phpDocumentor/Application/Configuration/CommandlineOptionsMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Application/Configuration/CommandlineOptionsMiddlewareTest.php
@@ -13,6 +13,7 @@
 namespace phpDocumentor\Application\Configuration;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use phpDocumentor\Application\Configuration\Factory\Version3;
 use phpDocumentor\DomainModel\Dsn;
 use phpDocumentor\DomainModel\Path;
 
@@ -99,4 +100,24 @@ final class CommandlineOptionsMiddlewareTest extends MockeryTestCase
 
         $this->assertSame([$expected], $newConfiguration['phpdocumentor']['templates']);
     }
+
+    /**
+     * @covers ::provideOptions
+     * @covers ::__invoke
+     */
+    public function testItShouldAddSourceDirectoriesForDefaultConfiguration()
+    {
+        $configuration = Version3::buildDefault();
+        $this->middleware->provideOptions(['directory' => ['./src']]);
+        $newConfiguration = $this->middleware->__invoke($configuration);
+
+        $this->assertEquals(
+            [
+                'dsn' => new Dsn('file://.'),
+                'paths' => [new Path('./src')],
+            ],
+            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['source']
+        );
+    }
+
 }

--- a/tests/unit/phpDocumentor/Application/Configuration/ConfigurationFactoryTest.php
+++ b/tests/unit/phpDocumentor/Application/Configuration/ConfigurationFactoryTest.php
@@ -16,6 +16,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery as m;
 use org\bovigo\vfs\vfsStream;
 use phpDocumentor\Application\Configuration\Factory\Strategy;
+use phpDocumentor\Application\Configuration\Factory\Version3;
 use phpDocumentor\DomainModel\Uri;
 
 /**
@@ -182,5 +183,20 @@ final class ConfigurationFactoryTest extends MockeryTestCase
         $factory->get();
 
         $this->assertAttributeSame($afterMiddleware2Value, 'cachedConfiguration', $factory);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::createInstance
+     * @covers ::get
+     */
+    public function testThatDefaultConfigurationIsCreateWhenNonProvided()
+    {
+        $root = vfsStream::setup('dir');
+        $factory = ConfigurationFactory::createInstance([]);
+        $factory->replaceLocation(new Uri(vfsStream::url('dir/nonexisting.xml')));
+
+        $config = $factory->get();
+        $this->assertEquals(Version3::buildDefault(), $config);
     }
 }

--- a/tests/unit/phpDocumentor/Application/Stage/ConfigureTest.php
+++ b/tests/unit/phpDocumentor/Application/Stage/ConfigureTest.php
@@ -31,7 +31,7 @@ class ConfigureTest extends TestCase
     {
         $configFactory = new ConfigurationFactory(
             [new Version3(__DIR__ . '/../../../../../data/xsd/phpdoc.xsd')],
-            new Uri(__DIR__ . '/../../../data/phpDocumentor3XML.xml')
+            new Uri(__DIR__ . str_replace('/', DIRECTORY_SEPARATOR, '/../../../data/phpDocumentor3XML.xml'))
         );
 
         $fixture = new Configure($configFactory);

--- a/tests/unit/phpDocumentor/Application/Stage/Parser/ConfigureCacheTest.php
+++ b/tests/unit/phpDocumentor/Application/Stage/Parser/ConfigureCacheTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *  This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ *
+ */
+
+namespace phpDocumentor\Application\Stage\Parser;
+
+use \Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use phpDocumentor\DomainModel\Path;
+use Zend\Cache\Storage\StorageInterface;
+
+class ConfigureCacheTest extends MockeryTestCase
+{
+    /**
+     * @dataProvider cacheDirProvider
+     * @param $configuredPath
+     * @param $expectedPath
+     * @throws \Exception
+     */
+    public function testInvokeWithCachePath($configuredPath, $expectedPath)
+    {
+        $configuration = [
+                'phpdocumentor' => [
+                    'paths' => [
+                        'cache' => $configuredPath
+                    ]
+                ]
+        ];
+
+        $cacheStorage = m::mock(StorageInterface::class);
+        $cacheStorage->shouldReceive('getOptions->setCacheDir')->withArgs([$expectedPath])->once();
+
+        $stage = new ConfigureCache($cacheStorage);
+
+        self::assertSame($configuration, $stage($configuration));
+    }
+
+    public function cacheDirProvider()
+    {
+        return [
+            [
+                '/cache',
+                '/cache'
+            ],
+            [
+                'cache/relative',
+                getcwd() . DIRECTORY_SEPARATOR . 'cache/relative'
+            ],
+            [
+                new Path('/cache'),
+                '/cache'
+            ],
+            [
+                new Path('cache/relative'),
+                getcwd() . DIRECTORY_SEPARATOR . 'cache/relative'
+            ]
+        ];
+    }
+}

--- a/tests/unit/phpDocumentor/Application/Stage/Parser/ConfigureCacheTest.php
+++ b/tests/unit/phpDocumentor/Application/Stage/Parser/ConfigureCacheTest.php
@@ -8,7 +8,6 @@
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
  *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      http://phpdoc.org
- *
  */
 
 namespace phpDocumentor\Application\Stage\Parser;
@@ -22,18 +21,16 @@ class ConfigureCacheTest extends MockeryTestCase
 {
     /**
      * @dataProvider cacheDirProvider
-     * @param $configuredPath
-     * @param $expectedPath
      * @throws \Exception
      */
     public function testInvokeWithCachePath($configuredPath, $expectedPath)
     {
         $configuration = [
-                'phpdocumentor' => [
-                    'paths' => [
-                        'cache' => $configuredPath
-                    ]
-                ]
+            'phpdocumentor' => [
+                'paths' => [
+                    'cache' => $configuredPath,
+                ],
+            ],
         ];
 
         $cacheStorage = m::mock(StorageInterface::class);
@@ -48,21 +45,21 @@ class ConfigureCacheTest extends MockeryTestCase
     {
         return [
             [
-                '/cache',
-                '/cache'
+                '/tmp/cache',
+                '/tmp/cache',
             ],
             [
                 'cache/relative',
-                getcwd() . DIRECTORY_SEPARATOR . 'cache/relative'
+                getcwd() . DIRECTORY_SEPARATOR . 'cache/relative',
             ],
             [
-                new Path('/cache'),
-                '/cache'
+                new Path('/tmp/cache'),
+                '/tmp/cache',
             ],
             [
                 new Path('cache/relative'),
-                getcwd() . DIRECTORY_SEPARATOR . 'cache/relative'
-            ]
+                getcwd() . DIRECTORY_SEPARATOR . 'cache/relative',
+            ],
         ];
     }
 }


### PR DESCRIPTION
When cache dir was an Path object because it was created by the config
factory instead of using the default an exception was thrown. Symfony filesystem
expected a string. Since this was not covered by any test case this behavior was not
detected before.

refs #1960