### PR TITLE
Add support of module zend-servicemanager v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "zendframework/zend-i18n": "~2.1",
         "zendframework/zend-serializer": "~2.1",
         "zendframework/zend-servicemanager": "~2.1 || ~3.1",
-        "zendframework/zend-stdlib": "~2.1",
+        "zendframework/zend-stdlib": "~2.1 || ~3.1",
         "zetacomponents/document": ">=1.3.1"
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "zendframework/zend-filter": "~2.1",
         "zendframework/zend-i18n": "~2.1",
         "zendframework/zend-serializer": "~2.1",
-        "zendframework/zend-servicemanager": "~2.1",
+        "zendframework/zend-servicemanager": "~2.1 || ~3.1",
         "zendframework/zend-stdlib": "~2.1",
         "zetacomponents/document": ">=1.3.1"
     },


### PR DESCRIPTION
Composer package "doctrine/doctrine-orm-module" (Zend Framework Module that provides Doctrine ORM functionality),
 starting with version 2.1.0, depends on zend-servicemanager ^3.3

Signed-off-by: ofry <tim4job@bmail.ru>