### PR TITLE
Use cache folder in config for Twig

### DIFF
--- a/config/pipelines.yaml
+++ b/config/pipelines.yaml
@@ -1,41 +1,27 @@
 services:
-    phpdoc.application.pipeline:
-      class: 'League\Pipeline\Pipeline'
-      factory: ['phpDocumentor\Application\PipelineFactory', create]
-      arguments: ['@phpDocumentor\Application\Stage\Configure']
-
     phpdoc.command.run.pipeline:
       class: 'League\Pipeline\Pipeline'
       factory: ['phpDocumentor\Application\PipelineFactory', create]
-      arguments:
-        - '@phpdoc.application.pipeline'
-        - '@phpdoc.parse.pipeline.internal'
-        - '@phpdoc.transform.pipeline.internal'
+      arguments: [!tagged phpdoc.pipeline.api_documentation.generate]
+
+    phpdoc.application.pipeline:
+      class: 'League\Pipeline\Pipeline'
+      factory: ['phpDocumentor\Application\PipelineFactory', create]
+      arguments: [!tagged phpdoc.pipeline.application]
+      tags:
+        - { name: 'phpdoc.pipeline.api_documentation.transform', priority: 10000 }
+        - { name: 'phpdoc.pipeline.api_documentation.parse', priority: 10000 }
 
     phpdoc.command.parse.pipeline:
       class: 'League\Pipeline\Pipeline'
       factory: ['phpDocumentor\Application\PipelineFactory', create]
-      arguments:
-        - '@phpdoc.application.pipeline'
-        - '@phpdoc.parse.pipeline.internal'
-
-    phpdoc.parse.pipeline.internal:
-      class: 'League\Pipeline\Pipeline'
-      factory: ['phpDocumentor\Application\PipelineFactory', create]
-      arguments:
-        - '@phpDocumentor\Application\Stage\Parser\ConfigureCache'
-        - '@phpDocumentor\Application\Stage\Parser'
+      arguments: [!tagged phpdoc.pipeline.api_documentation.parse]
+      tags:
+        - { name: 'phpdoc.pipeline.api_documentation.generate', priority: 10000 }
 
     phpdoc.command.transform.pipeline:
       class: 'League\Pipeline\Pipeline'
       factory: ['phpDocumentor\Application\PipelineFactory', create]
-      arguments:
-        - '@phpdoc.application.pipeline'
-        - '@phpdoc.transform.pipeline.internal'
-
-    phpdoc.transform.pipeline.internal:
-      class: 'League\Pipeline\Pipeline'
-      factory: ['phpDocumentor\Application\PipelineFactory', create]
-      arguments:
-        - '@phpDocumentor\Application\Stage\Parser\ConfigureCache'
-        - '@phpDocumentor\Application\Stage\Transform'
+      arguments: [!tagged phpdoc.pipeline.api_documentation.transform]
+      tags:
+        - { name: 'phpdoc.pipeline.api_documentation.generate', priority: 5000 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,5 +1,6 @@
 imports:
   - { resource: 'pipelines.yaml' }
+  - { resource: 'stages.yaml' }
 
 parameters:
     locale: 'en'
@@ -59,8 +60,6 @@ services:
         autowire: true
         autoconfigure: true
         public: false
-        bind:
-          Zend\Cache\Storage\StorageInterface: '@Zend\Cache\Storage\Adapter\Filesystem'
 
     ###################################################################################
     ## Autoloading definitions for whole namespaces ###################################
@@ -77,9 +76,6 @@ services:
 
     phpDocumentor\Descriptor\:
         resource: '../src/phpDocumentor/Descriptor'
-
-    phpDocumentor\Application\Stage\:
-        resource: '../src/phpDocumentor/Application/Stage'
 
     phpDocumentor\Parser\Middleware\:
         resource: '../src/phpDocumentor/Parser/Middleware'
@@ -104,6 +100,7 @@ services:
 
     phpDocumentor\Application\Console\Command\Project\RunCommand:
         arguments: ['@phpDocumentor\Descriptor\ProjectDescriptorBuilder', '@phpdoc.command.run.pipeline']
+
     phpDocumentor\Application\Console\Command\Project\ParseCommand:
         arguments: ['@phpdoc.command.parse.pipeline', '@phpDocumentor\Translator\Translator']
 
@@ -129,10 +126,6 @@ services:
     phpDocumentor\Application\Configuration\ConfigurationFactory:
         factory: ['phpDocumentor\Application\Configuration\ConfigurationFactory', createInstance]
         arguments: [!tagged phpdoc.config_stategy]
-
-    phpDocumentor\Application\Stage\Parser:
-      arguments:
-        $fileCollector: '@phpDocumentor\Infrastructure\Parser\FlySystemCollector'
 
     phpDocumentor\Compiler\Linker\Linker:
       arguments: ['%linker.substitutions%']
@@ -227,19 +220,28 @@ services:
     ## Service aliases for backwards compatibility ####################################
     ###################################################################################
 
-    compiler: '@phpDocumentor\Compiler\Compiler'
-    parser: '@phpDocumentor\Parser\Parser'
-    markdown: '@Parsedown'
-    descriptor.builder: '@phpDocumentor\Descriptor\ProjectDescriptorBuilder'
+    markdown:
+      alias: Parsedown
+      # used in a service provider so must be public
+      public: true
 
     translator:
       alias: phpDocumentor\Translator\Translator
+      # used in a service provider so must be public
       public: true
 
     transformer.routing.standard:
       alias: phpDocumentor\Transformer\Router\StandardRouter
+      # used in a service provider so must be public
       public: true
 
     transformer.writer.collection:
       alias: phpDocumentor\Transformer\Writer\Collection
+      # used in a service provider so must be public
       public: true
+
+    Twig\Environment:
+      # used in a service provider so must be public
+      public: true
+
+    Zend\Cache\Storage\StorageInterface: '@Zend\Cache\Storage\Adapter\Filesystem'

--- a/config/stages.yaml
+++ b/config/stages.yaml
@@ -1,0 +1,27 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    phpDocumentor\Application\Stage\Configure:
+      tags:
+        - { name: 'phpdoc.pipeline.application', priority: 10000 }
+
+    phpDocumentor\Application\Stage\Parser\ConfigureCache:
+      tags:
+        - { name: 'phpdoc.pipeline.api_documentation.transform', priority: 9000 }
+        - { name: 'phpdoc.pipeline.api_documentation.parse', priority: 9000 }
+
+    phpDocumentor\Application\Stage\Parser:
+      arguments:
+        $fileCollector: '@phpDocumentor\Infrastructure\Parser\FlySystemCollector'
+      tags:
+        - { name: 'phpdoc.pipeline.api_documentation.parse', priority: 0 }
+
+    phpDocumentor\Plugin\Twig\Stage\ConfigureTwig:
+      tags:
+        - { name: 'phpdoc.pipeline.api_documentation.transform', priority: 9000 }
+
+    phpDocumentor\Application\Stage\Transform:
+      tags:
+        - { name: 'phpdoc.pipeline.api_documentation.transform', priority: 0 }

--- a/src/phpDocumentor/Application/PipelineFactory.php
+++ b/src/phpDocumentor/Application/PipelineFactory.php
@@ -20,7 +20,7 @@ use League\Pipeline\PipelineInterface;
 
 final class PipelineFactory
 {
-    public static function create(callable ...$stages): PipelineInterface
+    public static function create(iterable $stages): PipelineInterface
     {
         $builder = new PipelineBuilder();
         foreach ($stages as $stage) {

--- a/src/phpDocumentor/Plugin/Twig/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/Twig/ServiceProvider.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Plugin\Twig;
 
+use phpDocumentor\Transformer\Writer\Collection;
+use phpDocumentor\Translator\Translator;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -40,8 +42,7 @@ class ServiceProvider implements ServiceProviderInterface
 
         /** @var Collection $writerCollection */
         $writerCollection = $app['transformer.writer.collection'];
-
-        $writerCollection['twig'] = new Writer\Twig();
+        $writerCollection['twig'] = new Writer\Twig($app[\Twig\Environment::class]);
         $writerCollection['twig']->setTranslator($translator);
     }
 }

--- a/src/phpDocumentor/Plugin/Twig/Stage/ConfigureTwig.php
+++ b/src/phpDocumentor/Plugin/Twig/Stage/ConfigureTwig.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Plugin\Twig\Stage;
+
+use Twig\Environment;
+
+final class ConfigureTwig
+{
+    /** @var Environment */
+    private $twig;
+
+    public function __construct(Environment $twig)
+    {
+        $this->twig = $twig;
+    }
+
+    public function __invoke(array $configuration): array
+    {
+        // set the cache directory to be a subdirectory of phpDocumentor's cache, this will make it configurable
+        // to be per-project instead of system-wide.
+        $this->twig->setCache((string)$configuration['phpdocumentor']['paths']['cache'] . '/twig');
+
+        return $configuration;
+    }
+}

--- a/src/phpDocumentor/Plugin/Twig/Writer/Twig.php
+++ b/src/phpDocumentor/Plugin/Twig/Writer/Twig.php
@@ -94,6 +94,14 @@ class Twig extends WriterAbstract implements Routable
     /** @var Translator $translator */
     protected $translator;
 
+    /** @var Twig_Environment $twig */
+    private $twig;
+
+    public function __construct(Twig_Environment $twig)
+    {
+        $this->twig = $twig;
+    }
+
     /**
      * This method combines the ProjectDescriptor and the given target template
      * and creates a static html page at the artifact location.
@@ -148,10 +156,10 @@ class Twig extends WriterAbstract implements Routable
             array_unshift($templateFolders, $path);
         }
 
-        $env = new Twig_Environment(
-            new Twig_Loader_Filesystem($templateFolders),
-            ['cache' => sys_get_temp_dir() . '/phpdoc-twig-cache']
-        );
+        // Clone twig because otherwise we cannot re-set the extensions on this twig environment on every run of this
+        // writer
+        $env = clone $this->twig;
+        $env->setLoader(new Twig_Loader_Filesystem($templateFolders));
 
         $this->addPhpDocumentorExtension($project, $transformation, $destination, $env);
         $this->addExtensionsFromTemplateConfiguration($transformation, $project, $env);

--- a/tests/unit/phpDocumentor/Application/PipelineFactoryTest.php
+++ b/tests/unit/phpDocumentor/Application/PipelineFactoryTest.php
@@ -10,10 +10,10 @@ final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function test_creates_a_pipeline_with_the_given_series_of_stages()
     {
-        $pipeline = PipelineFactory::create(
+        $pipeline = PipelineFactory::create([
             function($value) { return $value + 1; },
             function($value) { return $value * 2; }
-        );
+        ]);
 
         // can only test whether it worked by running the pipeline and
         // getting the expected output

--- a/tests/unit/phpDocumentor/Plugin/Twig/ServiceProviderTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Twig/ServiceProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Plugin\Twig;
+
+use phpDocumentor\Transformer\Router\Queue;
+use phpDocumentor\Transformer\Writer\Collection;
+use phpDocumentor\Translator\Translator;
+use Pimple\Container;
+use Symfony\Component\DependencyInjection\Container as SymfonyContainer;
+
+final class ServiceProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Container */
+    private $container;
+
+    /** @var Collection */
+    private $writerCollection;
+
+    public function setUp()
+    {
+        $this->container = new Container(new SymfonyContainer());
+        $this->writerCollection = new Collection(new Queue());
+
+        $this->container['translator'] = new Translator();
+        $this->container['transformer.writer.collection'] = $this->writerCollection;
+        $this->container[\Twig\Environment::class] = new \Twig\Environment();
+    }
+
+    public function test_that_the_twig_writer_is_set()
+    {
+        $serviceProvider = new ServiceProvider();
+        $serviceProvider->register($this->container);
+
+        $this->assertTrue(isset($this->writerCollection['twig']));
+    }
+}

--- a/tests/unit/phpDocumentor/Plugin/Twig/Stage/ConfigureTwigTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Twig/Stage/ConfigureTwigTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Plugin\Twig\Stage;
+
+final class ConfigureTwigTest extends \PHPUnit\Framework\TestCase
+{
+    public function test_that_the_cache_folder_gets_configured()
+    {
+        $twig = new \Twig\Environment();
+        $config = [ 'phpdocumentor' => [ 'paths' => [ 'cache' => 'phpdoc-cache' ] ] ];
+
+        (new ConfigureTwig($twig))($config);
+
+        $this->assertSame('phpdoc-cache/twig', $twig->getCache());
+    }
+}


### PR DESCRIPTION
Prior to this change the Twig cache files were stored in the system's temp
directory. Although this works in many cases, it may lead to issues when
different projects have different twig files.

This change includes two things:

1. Change pipelines to read stages using tags
2. Introduce a new stage that sets the Twig cache folder to use a subfolder
   of the configured cache folder.

By changing the pipelines we can dynamically introduce a new stage in the
pipeline with a specific priority. This new stage reads the configuration
and preconfigures the twig service.