### PR TITLE
Fix the functions/methods signatures

### DIFF
--- a/data/templates/clean/elements/method.html.twig
+++ b/data/templates/clean/elements/method.html.twig
@@ -5,7 +5,7 @@
             <article class="method">
                 <h3 class="{{ method.visibility }} {% if method.deprecated %}deprecated{% endif %}">{{ method.name }}()</h3>
                 <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">{{ method.name }}({% for argument in method.arguments %}{{ argument.types ? argument.types|join('|')~' ' }} <span class="argument">{{ argument.isVariadic ? '...' }}{{ argument.name }}{{ argument.default ? ' = '~argument.default }}</span>{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.types ? ': '~method.response.types|route|join('|') }}</pre>
+                <pre class="signature" style="margin-right: 54px;">{{ method.name }}({% for argument in method.arguments %}{{ argument.types ? argument.types|route|join('|')~' ' }} <span class="argument">{{ argument.isVariadic ? '...' }}{{ argument.name }}{{ argument.default ? ' = '~argument.default }}</span>{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.types ? ': '~method.response.types|route|join('|') }}</pre>
                 <p><em>{{ method.summary }}</em></p>
                 {{ method.description|markdown|raw }}
 

--- a/data/templates/clean/elements/method.html.twig
+++ b/data/templates/clean/elements/method.html.twig
@@ -5,7 +5,7 @@
             <article class="method">
                 <h3 class="{{ method.visibility }} {% if method.deprecated %}deprecated{% endif %}">{{ method.name }}()</h3>
                 <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">{{ method.name }}({% for argument in method.arguments %}{{ argument.types ? argument.types|join('|')~' ' }} <span class="argument">{{ argument.isVariadic ? '...' }}{{ argument.name }}{{ argument.default ? ' = '~argument.default }}</span>{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.types ? ': '~method.response.types|join('|') }}</pre>
+                <pre class="signature" style="margin-right: 54px;">{{ method.name }}({% for argument in method.arguments %}{{ argument.types ? argument.types|join('|')~' ' }} <span class="argument">{{ argument.isVariadic ? '...' }}{{ argument.name }}{{ argument.default ? ' = '~argument.default }}</span>{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.types ? ': '~method.response.types|route|join('|') }}</pre>
                 <p><em>{{ method.summary }}</em></p>
                 {{ method.description|markdown|raw }}
 

--- a/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
@@ -135,4 +135,9 @@ class ArgumentDescriptor extends DescriptorAbstract implements Interfaces\Argume
     {
         return $this->isVariadic;
     }
+
+    public function getName()
+    {
+        return "$" . parent::getName();
+    }
 }

--- a/src/phpDocumentor/Transformer/Router/Renderer.php
+++ b/src/phpDocumentor/Transformer/Router/Renderer.php
@@ -236,6 +236,6 @@ class Renderer
                 break;
         }
 
-        return $url ? sprintf('<a href="%s">%s</a>', $url, $path) : $path;
+        return $url ? sprintf('<a href="%s">%s</a>', $url, $path) : (string)$path;
     }
 }


### PR DESCRIPTION
After version v3.0.0-alpha.3 was release, there is still a bug on displaying scalar return type. Not nullable types (`int`, `bool`, ...) is missing from the output HTML while the nullable types (`?int`, `?bool`, ...) is displayed incorrectly as `int`, `bool`, ...

For example, this is a test input file:
```php
<?php

class Foo {
	public function getInt(): int {return 1;}
	public function getOptionalInt(): ?int {return null;}
}
```

With the v3.0.0-alpha.3 release, the output document is:
![screenshot_2018-10-23 my docs](https://user-images.githubusercontent.com/1145335/47331269-a0c4cc80-d6a5-11e8-9fc8-d4358a979347.png)




With this PR, the output document is
![screenshot_2018-10-23 my docs 1](https://user-images.githubusercontent.com/1145335/47331294-bcc86e00-d6a5-11e8-81b8-a1695f3b3597.png)



This PR also fixes #2020 