### PR TITLE
Fix crash with ini_set when opcache is enabled on CLI

### DIFF
--- a/src/phpDocumentor/Application.php
+++ b/src/phpDocumentor/Application.php
@@ -88,9 +88,9 @@ class Application extends Cilex
         // @codeCoverageIgnoreStart
         if (extension_loaded('Zend OPcache') && ini_get('opcache.enable') && ini_get('opcache.enable_cli')) {
             if (ini_get('opcache.save_comments')) {
-                ini_set('opcache.load_comments', 1);
+                ini_set('opcache.load_comments', '1');
             } else {
-                ini_set('opcache.enable', 0);
+                ini_set('opcache.enable', '0');
             }
         }
 


### PR DESCRIPTION
The error was:
FatalThrowableError: ini_set() expects parameter 2 to be string, int given

This happened during the cache:clear step.

This bug is not on the `master` branch, which doesn't use strict_types