### PR TITLE
Deduplicate types

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/AssemblerAbstract.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/AssemblerAbstract.php
@@ -19,6 +19,8 @@ use phpDocumentor\Descriptor\Builder\AssemblerAbstract as BaseAssembler;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Compound;
 
 abstract class AssemblerAbstract extends BaseAssembler
 {
@@ -70,5 +72,19 @@ abstract class AssemblerAbstract extends BaseAssembler
         $tag = reset($packageTags);
 
         return trim((string) $tag->getDescription());
+    }
+
+    public static function deduplicateTypes(?Type $type): ?Type {
+
+        if ($type instanceof Compound) {
+            $normalizedTypes = [];
+            foreach ($type as $typePart) {
+                $normalizedTypes[(string)$typePart] = $typePart;
+            }
+
+            return new Compound(array_values($normalizedTypes));
+        }
+
+        return $type;
     }
 }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
@@ -63,7 +63,7 @@ class MethodAssembler extends AssemblerAbstract
     private function createArgumentDescriptorForMagicMethod(string $name, Type $type): ArgumentDescriptor
     {
         $argumentDescriptor = new ArgumentDescriptor();
-        $argumentDescriptor->setTypes($type);
+        $argumentDescriptor->setTypes(AssemblerAbstract::deduplicateTypes($type));
         $argumentDescriptor->setName($name);
 
         return $argumentDescriptor;

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ParamAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ParamAssembler.php
@@ -39,7 +39,7 @@ class ParamAssembler extends AssemblerAbstract
         $descriptor = new ParamDescriptor($data->getName());
         $descriptor->setDescription($data->getDescription());
         $descriptor->setVariableName($data->getVariableName());
-        $descriptor->setTypes($data->getType());
+        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/PropertyAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/PropertyAssembler.php
@@ -39,7 +39,7 @@ class PropertyAssembler extends AssemblerAbstract
         $descriptor = new PropertyDescriptor($data->getName());
         $descriptor->setVariableName($data->getVariableName());
         $descriptor->setDescription($data->getDescription());
-        $descriptor->setTypes($data->getType());
+        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ReturnAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ReturnAssembler.php
@@ -18,6 +18,7 @@ namespace phpDocumentor\Descriptor\Builder\Reflector\Tags;
 use phpDocumentor\Descriptor\Builder\Reflector\AssemblerAbstract;
 use phpDocumentor\Descriptor\Tag\ReturnDescriptor;
 use phpDocumentor\Reflection\DocBlock\Tags\Return_;
+use phpDocumentor\Reflection\Types\Compound;
 
 /**
  * Constructs a new descriptor from the Reflector for an `@return` tag.
@@ -38,7 +39,8 @@ class ReturnAssembler extends AssemblerAbstract
     {
         $descriptor = new ReturnDescriptor($data->getName());
         $descriptor->setDescription($data->getDescription());
-        $descriptor->setTypes($data->getType());
+
+        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ThrowsAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ThrowsAssembler.php
@@ -38,7 +38,7 @@ class ThrowsAssembler extends AssemblerAbstract
     {
         $descriptor = new ThrowsDescriptor($data->getName());
         $descriptor->setDescription($data->getDescription());
-        $descriptor->setTypes($data->getType());
+        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/VarAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/VarAssembler.php
@@ -40,7 +40,7 @@ class VarAssembler extends AssemblerAbstract
         $descriptor->setDescription($data->getDescription());
         $descriptor->setVariableName($data->getVariableName());
 
-        $descriptor->setTypes($data->getType());
+        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/tests/features/assets/singlefile/internals/conflate-types.php
+++ b/tests/features/assets/singlefile/internals/conflate-types.php
@@ -1,0 +1,12 @@
+<?php
+namespace My\FZZNamespace;
+
+class A
+{
+    /**
+     * @return self|\My\FZZNamespace\A|A
+     */
+    function test($test)
+    {
+    }
+}

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -358,8 +358,8 @@ class ApiContext extends BaseContext implements Context
     {
         $response = $this->findMethodResponse($classFqsen, $methodName);
 
-        Assert::eq($returnType, (string) $response->getTypes());
-        Assert::eq('', (string) $response->getDescription());
+        Assert::eq((string) $response->getTypes(), $returnType);
+        Assert::eq((string) $response->getDescription(), '');
     }
 
     /**

--- a/tests/features/core/internals/typeresolving.feature
+++ b/tests/features/core/internals/typeresolving.feature
@@ -1,0 +1,7 @@
+Feature: Phpdocumentor should correctly handle type resolving
+
+  @php7.1+ @github-562
+  Scenario: phpdocumentor should conflate duplicated types
+    Given A single file named "test.php" based on "internals/conflate-types.php"
+    When I run "phpdoc -f test.php"
+    Then class "\My\FZZNamespace\A" has a method "test" with returntype 'self|\My\FZZNamespace\A' without description

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/AssemblerAbstractTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/AssemblerAbstractTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author    Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright 2010-2018 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ *
+ *
+ */
+
+namespace phpDocumentor\Descriptor\Builder\Reflector;
+
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\TestCase;
+
+class AssemblerAbstractTest extends TestCase
+{
+    /**
+     * @param Type|null $type
+     * @param string $expected
+     * @dataProvider typeProvider
+     */
+    public function testDeduplicateTypes(?Type $type, string $expected)
+    {
+        $type = AssemblerAbstract::deduplicateTypes($type);
+
+        self::assertEquals($expected, (string)$type);
+    }
+
+    public function typeProvider()
+    {
+        return [
+            [
+                new Compound([new String_(), new Integer()]),
+                'string|int'
+            ],
+            [
+                new Compound([new String_(), new String_()]),
+                'string'
+            ],
+            [
+                new String_(),
+                'string'
+            ],
+
+        ];
+    }
+}


### PR DESCRIPTION
When types are duplicated in Compound type, they are now deduplicated.
`string|string` be comes `string` in the documentation.

fixes #562