### PR TITLE
Restore orginal pre v3 type system

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1780,16 +1780,16 @@
         },
         {
             "name": "phpdocumentor/reflection",
-            "version": "4.0.0-alpha5",
+            "version": "4.0.0-alpha6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/Reflection.git",
-                "reference": "87e3801a58e06023941bdbab2f7241be261b5e7c"
+                "reference": "b4886422d87fc9330055b98b6bc5f0283d812b31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/87e3801a58e06023941bdbab2f7241be261b5e7c",
-                "reference": "87e3801a58e06023941bdbab2f7241be261b5e7c",
+                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/b4886422d87fc9330055b98b6bc5f0283d812b31",
+                "reference": "b4886422d87fc9330055b98b6bc5f0283d812b31",
                 "shasum": ""
             },
             "require": {
@@ -1825,7 +1825,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2018-10-12T19:40:10+00:00"
+            "time": "2018-12-31T12:18:13+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -41,20 +41,20 @@ parameters:
           - 'tags'
           - 'arguments'
       'phpDocumentor\Descriptor\ArgumentDescriptor':
-          - 'types'
+          - 'type'
       'phpDocumentor\Descriptor\PropertyDescriptor':
           - 'tags'
-          - 'types'
+          - 'type'
       'phpDocumentor\Descriptor\ConstantDescriptor':
           - 'tags'
-          - 'types'
-      'phpDocumentor\Descriptor\Tag\ParamDescriptor': ['types']
-      'phpDocumentor\Descriptor\Tag\ReturnDescriptor': ['types']
+          - 'type'
+      'phpDocumentor\Descriptor\Tag\ParamDescriptor': ['type']
+      'phpDocumentor\Descriptor\Tag\ReturnDescriptor': ['type']
       'phpDocumentor\Descriptor\Tag\SeeDescriptor': ['reference']
       'phpDocumentor\Descriptor\Tag\UsesDescriptor': ['reference']
       'phpDocumentor\Descriptor\Type\CollectionDescriptor':
           - 'baseType'
-          - 'types'
+          - 'type'
           - 'keyTypes'
 services:
     _defaults:

--- a/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor;
 
+use phpDocumentor\Reflection\Type;
+
 /**
  * Descriptor representing a single Argument of a method or function.
  */
@@ -23,8 +25,8 @@ class ArgumentDescriptor extends DescriptorAbstract implements Interfaces\Argume
     /** @var MethodDescriptor $method */
     protected $method;
 
-    /** @var string[] $type an array of normalized types that should be in this Argument */
-    protected $types = [];
+    /** @var Type|null $type normalized type of this argument */
+    protected $type = null;
 
     /** @var string|null $default the default value for an argument or null if none is provided */
     protected $default;
@@ -46,22 +48,27 @@ class ArgumentDescriptor extends DescriptorAbstract implements Interfaces\Argume
     /**
      * {@inheritDoc}
      */
-    public function setTypes($types)
+    public function setType(?Type $type)
     {
-        $this->types = $types;
+        $this->type = $type;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getTypes()
+    public function getType(): ?Type
     {
-        $countable = $this->types instanceof \Countable || is_array($this->types);
-        if ((!$countable || count($this->types) === 0) && $this->getInheritedElement() !== null) {
-            $this->setTypes($this->getInheritedElement()->getTypes());
+        if ($this->type === null && $this->getInheritedElement() !== null) {
+            $this->setType($this->getInheritedElement()->getType());
         }
 
-        return $this->types;
+        return $this->type;
+    }
+
+    public function getTypes(): array
+    {
+        trigger_error('Please use getType', E_USER_DEPRECATED);
+        return [$this->getType()];
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/ArgumentAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/ArgumentAssembler.php
@@ -36,7 +36,7 @@ class ArgumentAssembler extends AssemblerAbstract
     {
         $argumentDescriptor = new ArgumentDescriptor();
         $argumentDescriptor->setName($data->getName());
-        $argumentDescriptor->setTypes($data->getTypes());
+        $argumentDescriptor->setType($data->getType());
 
         foreach ($params as $paramDescriptor) {
             $this->overwriteTypeAndDescriptionFromParamTag($data, $paramDescriptor, $argumentDescriptor);
@@ -61,6 +61,6 @@ class ArgumentAssembler extends AssemblerAbstract
         }
 
         $argumentDescriptor->setDescription($paramDescriptor->getDescription());
-        $argumentDescriptor->setTypes($paramDescriptor->getTypes());
+        $argumentDescriptor->setType($paramDescriptor->getType());
     }
 }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
@@ -123,7 +123,7 @@ class MethodAssembler extends AssemblerAbstract
 
             $argument = new ArgumentDescriptor();
             $argument->setName($lastParamTag->getVariableName());
-            $argument->setTypes($types);
+            $argument->setType($types);
             $argument->setDescription($lastParamTag->getDescription());
             $argument->setLine($methodDescriptor->getLine());
             $argument->setVariadic(true);

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
@@ -45,7 +45,7 @@ class MethodAssembler extends AssemblerAbstract
         $descriptor->setStatic($data->isStatic());
 
         $response = new ReturnDescriptor('return');
-        $response->setTypes($data->getReturnType());
+        $response->setType($data->getReturnType());
         $descriptor->setResponse($response);
 
         foreach ($data->getArguments() as $argument) {

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
@@ -63,7 +63,7 @@ class MethodAssembler extends AssemblerAbstract
     private function createArgumentDescriptorForMagicMethod(string $name, Type $type): ArgumentDescriptor
     {
         $argumentDescriptor = new ArgumentDescriptor();
-        $argumentDescriptor->setTypes(AssemblerAbstract::deduplicateTypes($type));
+        $argumentDescriptor->setType(AssemblerAbstract::deduplicateTypes($type));
         $argumentDescriptor->setName($name);
 
         return $argumentDescriptor;

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ParamAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ParamAssembler.php
@@ -39,7 +39,7 @@ class ParamAssembler extends AssemblerAbstract
         $descriptor = new ParamDescriptor($data->getName());
         $descriptor->setDescription($data->getDescription());
         $descriptor->setVariableName($data->getVariableName());
-        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
+        $descriptor->setType(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/PropertyAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/PropertyAssembler.php
@@ -39,7 +39,7 @@ class PropertyAssembler extends AssemblerAbstract
         $descriptor = new PropertyDescriptor($data->getName());
         $descriptor->setVariableName($data->getVariableName());
         $descriptor->setDescription($data->getDescription());
-        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
+        $descriptor->setType(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ReturnAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ReturnAssembler.php
@@ -39,8 +39,7 @@ class ReturnAssembler extends AssemblerAbstract
     {
         $descriptor = new ReturnDescriptor($data->getName());
         $descriptor->setDescription($data->getDescription());
-
-        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
+        $descriptor->setType(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ThrowsAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ThrowsAssembler.php
@@ -38,7 +38,7 @@ class ThrowsAssembler extends AssemblerAbstract
     {
         $descriptor = new ThrowsDescriptor($data->getName());
         $descriptor->setDescription($data->getDescription());
-        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
+        $descriptor->setType(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/VarAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/VarAssembler.php
@@ -40,7 +40,7 @@ class VarAssembler extends AssemblerAbstract
         $descriptor->setDescription($data->getDescription());
         $descriptor->setVariableName($data->getVariableName());
 
-        $descriptor->setTypes(AssemblerAbstract::deduplicateTypes($data->getType()));
+        $descriptor->setType(AssemblerAbstract::deduplicateTypes($data->getType()));
 
         return $descriptor;
     }

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -284,7 +284,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
             $property = new PropertyDescriptor();
             $property->setName(ltrim($propertyTag->getVariableName(), '$'));
             $property->setDescription($propertyTag->getDescription());
-            $property->setTypes($propertyTag->getTypes());
+            $property->setTypes($propertyTag->getType());
             $property->setParent($this);
 
             $properties->add($property);

--- a/src/phpDocumentor/Descriptor/ConstantDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ConstantDescriptor.php
@@ -26,7 +26,7 @@ class ConstantDescriptor extends DescriptorAbstract implements Interfaces\Consta
     /** @var ClassDescriptor|InterfaceDescriptor|null $parent */
     protected $parent;
 
-    /** @var string[]|null $type */
+    /** @var Type $type */
     protected $types;
 
     /** @var string $value */
@@ -75,11 +75,16 @@ class ConstantDescriptor extends DescriptorAbstract implements Interfaces\Consta
      */
     public function getTypes()
     {
+        return [$this->getType()];
+    }
+
+    public function getType()
+    {
         if ($this->types === null) {
             /** @var VarDescriptor $var */
             $var = $this->getVar()->get(0);
             if ($var) {
-                return $var->getTypes();
+                return $var->getType();
             }
         }
 

--- a/src/phpDocumentor/Descriptor/FunctionDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FunctionDescriptor.php
@@ -61,7 +61,7 @@ class FunctionDescriptor extends DescriptorAbstract implements Interfaces\Functi
     public function getResponse(): ReturnDescriptor
     {
         $definedReturn = new ReturnDescriptor('return');
-        $definedReturn->setTypes($this->returnType);
+        $definedReturn->setType($this->returnType);
 
         /** @var Collection|null $returnTags */
         $returnTags = $this->getTags()->get('return');

--- a/src/phpDocumentor/Descriptor/Interfaces/ArgumentInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/ArgumentInterface.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Interfaces;
 
-use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Reflection\Type;
 
 /**
  * Describes the public interface for a descriptor of an Argument.
@@ -32,23 +32,23 @@ interface ArgumentInterface extends ElementInterface
      * backslash. Types that do not represent a class/interface/trait should be written in lowercaps and should not be
      * preceded by a backslash.
      *
-     * @param Collection $types An Collection of normalized types that should be in this Argument
+     * @param ?Type $type Type of this agument represented as a reflection type.
      *
      * @link https://github.com/phpDocumentor/phpDocumentor2/blob/develop/docs/PSR.md#appendix-a-types Definition of a
      *     type.
      *
      * @todo update link to point to the final destination for the PHPDoc Standard.
      */
-    public function setTypes($types);
+    public function setType(?Type $type);
 
     /**
-     * Returns a normalized list of types.
+     * Returns a normalized Types.
      *
      * @see self::setTypes() for details on what types represent.
      *
-     * @return Collection
+     * @return Type|null
      */
-    public function getTypes();
+    public function getType(): ?Type;
 
     /**
      * Sets the default value for an argument expressed as a string.

--- a/src/phpDocumentor/Descriptor/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/MethodDescriptor.php
@@ -173,7 +173,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
     public function getResponse(): ReturnDescriptor
     {
         $definedReturn = new ReturnDescriptor('return');
-        $definedReturn->setTypes($this->returnType);
+        $definedReturn->setType($this->returnType);
 
         /** @var Collection|null $returnTags */
         $returnTags = $this->getReturn();

--- a/src/phpDocumentor/Descriptor/PropertyDescriptor.php
+++ b/src/phpDocumentor/Descriptor/PropertyDescriptor.php
@@ -103,13 +103,16 @@ class PropertyDescriptor extends DescriptorAbstract implements Interfaces\Proper
      */
     public function getTypes()
     {
-        if (!$this->types) {
-            $this->types = new Collection();
+        return [$this->getType()];
+    }
 
+    public function getType()
+    {
+        if ($this->types === null) {
             /** @var VarDescriptor $var */
             $var = $this->getVar()->getIterator()->current();
             if ($var) {
-                $this->types = $var->getTypes();
+                return $var->getType();
             }
         }
 

--- a/src/phpDocumentor/Descriptor/Tag/BaseTypes/TypedAbstract.php
+++ b/src/phpDocumentor/Descriptor/Tag/BaseTypes/TypedAbstract.php
@@ -31,13 +31,29 @@ abstract class TypedAbstract extends TagDescriptor
      */
     public function setTypes(Type $types = null)
     {
+        trigger_error('Use setType, because type is an object', E_USER_DEPRECATED);
         $this->types = $types;
     }
 
     /**
+     * Sets a list of types associated with this tag.
+     */
+    public function setType(Type $types = null)
+    {
+        $this->types = $types;
+    }
+
+
+    /**
      * Returns the list of types associated with this tag.
      */
-    public function getTypes(): ?Type
+    public function getTypes(): array
+    {
+        trigger_error('Use getType, because type is an object', E_USER_DEPRECATED);
+        return array_filter([$this->types]);
+    }
+
+    public function getType()
     {
         return $this->types;
     }

--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -130,7 +130,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
             $property = new PropertyDescriptor();
             $property->setName(ltrim($propertyTag->getVariableName(), '$'));
             $property->setDescription($propertyTag->getDescription());
-            $property->setTypes($propertyTag->getTypes());
+            $property->setTypes($propertyTag->getType());
             $property->setParent($this);
 
             $properties->add($property);

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/ArgumentConverter.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/ArgumentConverter.php
@@ -46,16 +46,7 @@ class ArgumentConverter
         $child->appendChild(new \DOMElement('default'))
             ->appendChild(new \DOMText((string) $argument->getDefault()));
 
-        $types = $argument->getTypes();
-
-        $typeStrings = [];
-        foreach ($types as $type) {
-            $typeStrings[] = $type instanceof DescriptorAbstract
-                ? $type->getFullyQualifiedStructuralElementName()
-                : $type;
-        }
-
-        $child->appendChild(new \DOMElement('type', implode('|', $typeStrings)));
+        $child->appendChild(new \DOMElement('type', (string) $argument->getType()));
 
         return $child;
     }

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/TagConverter.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/TagConverter.php
@@ -107,7 +107,7 @@ class TagConverter
         $typeString = '';
 
         if ($tag instanceof TypedAbstract) {
-            $types = $tag->getTypes();
+            $types = $tag->getType();
 
             if ($types instanceof \IteratorAggregate) {
                 foreach ($types as $type) {

--- a/src/phpDocumentor/Transformer/Router/Renderer.php
+++ b/src/phpDocumentor/Transformer/Router/Renderer.php
@@ -18,6 +18,7 @@ namespace phpDocumentor\Transformer\Router;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\Type\CollectionDescriptor;
+use phpDocumentor\Reflection\Type;
 
 /**
  * Renders an HTML anchor pointing to the location of the provided element.
@@ -98,6 +99,10 @@ class Renderer
      */
     public function render($value, $presentation)
     {
+        if (is_array($value) && current($value) instanceof Type) {
+            return $this->renderType($value, $presentation);
+        }
+
         if (is_array($value) || $value instanceof \Traversable || $value instanceof Collection) {
             return $this->renderASeriesOfLinks($value, $presentation);
         }
@@ -237,5 +242,15 @@ class Renderer
         }
 
         return $url ? sprintf('<a href="%s">%s</a>', $url, $path) : $path;
+    }
+
+    private function renderType($value, string $presentation)
+    {
+        $result = [];
+        foreach ($value as $type) {
+            $result[] = (string) $type;
+        }
+
+        return $result;
     }
 }

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -263,7 +263,7 @@ class ApiContext extends BaseContext implements Context
         /** @var ArgumentDescriptor $argumentDescriptor */
         $argumentDescriptor = $method->getArguments()[$argument];
 
-        Assert::eq($type, (string) $argumentDescriptor->getTypes());
+        Assert::eq($type, (string) $argumentDescriptor->getType());
     }
 
     /**
@@ -281,7 +281,7 @@ class ApiContext extends BaseContext implements Context
         /** @var ParamDescriptor $paramDescriptor */
         foreach ($method->getParam() as $paramDescriptor) {
             if ($paramDescriptor->getName() === $param) {
-                Assert::eq($type, (string) $paramDescriptor->getTypes());
+                Assert::eq($type, (string) $paramDescriptor->getType());
             }
         }
     }
@@ -358,7 +358,7 @@ class ApiContext extends BaseContext implements Context
     {
         $response = $this->findMethodResponse($classFqsen, $methodName);
 
-        Assert::eq((string) $response->getTypes(), $returnType);
+        Assert::eq((string) $response->getType(), $returnType);
         Assert::eq((string) $response->getDescription(), '');
     }
 
@@ -373,8 +373,8 @@ class ApiContext extends BaseContext implements Context
     {
         $response = $this->findMagicMethodResponse($classFqsen, $methodName);
 
-        Assert::eq($returnType, (string) $response->getTypes());
-        Assert::eq('', (string) $response->getDescription());
+        Assert::eq((string) $response->getType(), $returnType);
+        Assert::eq((string) $response->getDescription(), '');
     }
 
     /**
@@ -387,7 +387,7 @@ class ApiContext extends BaseContext implements Context
     {
         $response = $this->findMethodResponse($classFqsen, $methodName);
 
-        Assert::eq($returnType, (string) $response->getTypes());
+        Assert::eq($returnType, (string) $response->getType());
         Assert::eq($description, (string) $response->getDescription());
     }
 
@@ -398,7 +398,7 @@ class ApiContext extends BaseContext implements Context
     public function classReturnTaggetReturnWithoutAnyWithoutReturntype($classFqsen, $methodName)
     {
         $response = $this->findMethodResponse($classFqsen, $methodName);
-        Assert::eq('mixed', (string) $response->getTypes());
+        Assert::eq('mixed', (string) $response->getType());
         Assert::eq('', $response->getDescription());
     }
 
@@ -411,7 +411,7 @@ class ApiContext extends BaseContext implements Context
     {
         $response = $this->findFunctionResponse($fqsen);
 
-        Assert::eq($returnType, (string) $response->getTypes());
+        Assert::eq($returnType, (string) $response->getType());
         Assert::eq('', (string) $response->getDescription());
     }
 
@@ -423,7 +423,7 @@ class ApiContext extends BaseContext implements Context
     {
         $response = $this->findFunctionResponse($fqsen);
 
-        Assert::eq($returnType, (string) $response->getTypes());
+        Assert::eq($returnType, (string) $response->getType());
         Assert::eq($description, (string) $response->getDescription());
     }
 
@@ -434,7 +434,7 @@ class ApiContext extends BaseContext implements Context
     public function functionWithoutReturntype($fqsen)
     {
         $response = $this->findFunctionResponse($fqsen);
-        Assert::eq('mixed', (string) $response->getTypes());
+        Assert::eq('mixed', (string) $response->getType());
         Assert::eq('', $response->getDescription());
     }
 

--- a/tests/features/bootstrap/EnvironmentContext.php
+++ b/tests/features/bootstrap/EnvironmentContext.php
@@ -50,6 +50,8 @@ final class EnvironmentContext implements Context\Context
      */
     public function beforeScenario()
     {
+        //WE no we have some deprecations in phpdocumentor. Let tests pass while we are refactoring stuff.
+        error_reporting(error_reporting() & ~E_USER_DEPRECATED);
         if (!is_dir($this->getWorkingDir())) {
             mkdir($this->getWorkingDir(), 0755, true);
         }

--- a/tests/unit/phpDocumentor/Descriptor/ArgumentDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ArgumentDescriptorTest.php
@@ -11,6 +11,9 @@
 
 namespace phpDocumentor\Descriptor;
 
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\String_;
+
 /**
  * @coversDefaultClass \phpDocumentor\Descriptor\ArgumentDescriptor
  */
@@ -28,16 +31,17 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * @covers ::getTypes
-     * @covers ::setTypes
+     * @covers ::getType
+     * @covers ::setType
      */
     public function testSetAndGetTypes()
     {
-        $this->assertSame([], $this->fixture->getTypes());
+        $this->assertSame(null, $this->fixture->getType());
 
-        $this->fixture->setTypes([1]);
+        $type = new Integer();
+        $this->fixture->setType($type);
 
-        $this->assertSame([1], $this->fixture->getTypes());
+        $this->assertSame($type, $this->fixture->getType());
     }
 
     /**
@@ -114,17 +118,17 @@ class ArgumentDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     }
 
     /**
-     * @covers ::getTypes
+     * @covers ::getType
      */
     public function testTypeIsInheritedWhenNoneIsPresent()
     {
         // Arrange
-        $types = ['string'];
-        $this->fixture->setTypes(null);
+        $types = new String_();
+        $this->fixture->setType(null);
         $parentArgument = $this->whenFixtureHasMethodAndArgumentInParentClassWithSameName('same_argument');
-        $parentArgument->setTypes($types);
+        $parentArgument->setType($types);
         // Act
-        $result = $this->fixture->getTypes();
+        $result = $this->fixture->getType();
 
         // Assert
         $this->assertSame($types, $result);

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/ArgumentAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/ArgumentAssemblerTest.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Descriptor\Builder\Reflector;
 use Mockery as m;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use phpDocumentor\Reflection\Php\Argument;
+use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Boolean;
 
 /**
@@ -46,7 +47,7 @@ class ArgumentAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     {
         // Arrange
         $name = 'goodArgument';
-        $type = 'boolean';
+        $type = new Boolean();
 
         $argumentReflectorMock = $this->givenAnArgumentReflectorWithNameAndType($name, $type);
 
@@ -55,7 +56,7 @@ class ArgumentAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
         // Assert
         $this->assertSame($name, $descriptor->getName());
-        $this->assertSame([$type], $descriptor->getTypes());
+        $this->assertSame($type, $descriptor->getType());
         $this->assertNull($descriptor->getDefault());
         $this->assertFalse($descriptor->isByReference());
     }
@@ -76,27 +77,25 @@ class ArgumentAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $paramDescriptorTagMock = m::mock('phpDocumentor\Descriptor\Tag\ParamDescriptor');
         $paramDescriptorTagMock->shouldReceive('getVariableName')->once()->andReturn($name);
         $paramDescriptorTagMock->shouldReceive('getDescription')->once()->andReturn('Is this a good argument, or nah?');
-        $paramDescriptorTagMock->shouldReceive('getTypes')->once()->andReturn($type);
+        $paramDescriptorTagMock->shouldReceive('getType')->once()->andReturn($type);
 
         // Act
         $descriptor = $this->fixture->create($argumentReflectorMock, [$paramDescriptorTagMock]);
 
         // Assert
         $this->assertSame($name, $descriptor->getName());
-        $this->assertSame($type, $descriptor->getTypes());
+        $this->assertSame($type, $descriptor->getType());
         $this->assertNull($descriptor->getDefault());
         $this->assertFalse($descriptor->isByReference());
     }
 
     /**
      * @param string $name
-     * @param string $type
      * @return Argument
      */
-    protected function givenAnArgumentReflectorWithNameAndType($name, $type)
+    protected function givenAnArgumentReflectorWithNameAndType(string $name, Type $type)
     {
-        $argument = new Argument($name);
-        $argument->addType($type);
+        $argument = new Argument($name, $type);
 
         return $argument;
     }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssemblerTest.php
@@ -21,6 +21,7 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Argument;
 use phpDocumentor\Reflection\Php\Function_;
+use phpDocumentor\Reflection\Types\Mixed_;
 
 class FunctionAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 {

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssemblerTest.php
@@ -59,12 +59,12 @@ class MethodAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
         $descriptor = $this->fixture->create($tag);
 
-        $this->assertEquals($returnType, $descriptor->getResponse()->getTypes());
+        $this->assertEquals($returnType, $descriptor->getResponse()->getType());
         $this->assertSame($name, $descriptor->getMethodName());
         $this->assertSame($description, $descriptor->getDescription());
         $this->assertSame(count($arguments), $descriptor->getArguments()->count());
         foreach ($arguments as $argument) {
-            $this->assertSame($argument['type'], $descriptor->getArguments()->get($argument['name'])->getTypes());
+            $this->assertSame($argument['type'], $descriptor->getArguments()->get($argument['name'])->getType());
             $this->assertSame($argument['name'], $descriptor->getArguments()->get($argument['name'])->getName());
         }
     }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/ParamAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/ParamAssemblerTest.php
@@ -38,6 +38,6 @@ class ParamAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame('param', $descriptor->getName());
         $this->assertSame('This is a description', (string) $descriptor->getDescription());
         $this->assertSame('$myParameter', $descriptor->getVariableName());
-        $this->assertEquals(new String_(), $descriptor->getTypes());
+        $this->assertEquals(new String_(), $descriptor->getType());
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/PropertyAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/PropertyAssemblerTest.php
@@ -38,6 +38,6 @@ class PropertyAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame('property', $descriptor->getName());
         $this->assertSame('This is a description', (string) $descriptor->getDescription());
         $this->assertSame('$myProperty', $descriptor->getVariableName());
-        $this->assertEquals(new String_(), $descriptor->getTypes());
+        $this->assertEquals(new String_(), $descriptor->getType());
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/ReturnAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/ReturnAssemblerTest.php
@@ -37,6 +37,6 @@ class ReturnAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->assertSame('return', $descriptor->getName());
         $this->assertSame('This is a description', (string) $descriptor->getDescription());
-        $this->assertEquals(new String_(), $descriptor->getTypes());
+        $this->assertEquals(new String_(), $descriptor->getType());
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/ThrowsAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/ThrowsAssemblerTest.php
@@ -42,6 +42,6 @@ class ThrowsAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->assertSame('throws', $descriptor->getName());
         $this->assertSame('This is a description', (string) $descriptor->getDescription());
-        $this->assertSame($types, $descriptor->getTypes());
+        $this->assertSame($types, $descriptor->getType());
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/VarAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/VarAssemblerTest.php
@@ -38,6 +38,6 @@ class VarAssemblerTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame('var', $descriptor->getName());
         $this->assertSame('This is a description', (string) $descriptor->getDescription());
         $this->assertSame('$myParameter', $descriptor->getVariableName());
-        $this->assertEquals(new String_(), $descriptor->getTypes());
+        $this->assertEquals(new String_(), $descriptor->getType());
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
@@ -237,7 +237,7 @@ class ClassDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $propertyMock = m::mock('phpDocumentor\Descriptor\Tag\PropertyDescriptor');
         $propertyMock->shouldReceive('getVariableName')->andReturn($variableName);
         $propertyMock->shouldReceive('getDescription')->andReturn($description);
-        $propertyMock->shouldReceive('getTypes')->andReturn(new String_());
+        $propertyMock->shouldReceive('getType')->andReturn(new String_());
 
         $this->fixture->getTags()->get('property', new Collection())->add($propertyMock);
 
@@ -249,7 +249,7 @@ class ClassDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $magicProperty = current($magicProperties->getAll());
         $this->assertEquals($variableName, $magicProperty->getName());
         $this->assertEquals($description, $magicProperty->getDescription());
-        $this->assertEquals(new String_(), $magicProperty->getTypes());
+        $this->assertEquals([new String_()], $magicProperty->getTypes());
 
         $mock = m::mock('phpDocumentor\Descriptor\ClassDescriptor');
         $mock->shouldReceive('getMagicProperties')->andReturn(new Collection(['magicProperties']));

--- a/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
@@ -371,7 +371,7 @@ class ClassDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $methodName = 'methodName';
         $description = 'description';
         $response = new ReturnDescriptor('return');
-        $response->setTypes(new String_());
+        $response->setType(new String_());
         $arguments = m::mock('phpDocumentor\Descriptor\Tag\ArgumentDescriptor');
         $arguments->shouldReceive('setMethod');
 

--- a/tests/unit/phpDocumentor/Descriptor/ConstantDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ConstantDescriptorTest.php
@@ -99,7 +99,7 @@ class ConstantDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $expected = new String_();
 
         $varTag = new VarDescriptor('var');
-        $varTag->setTypes($expected);
+        $varTag->setType($expected);
 
         $this->fixture->getTags()->set('var', new Collection([$varTag]));
 

--- a/tests/unit/phpDocumentor/Descriptor/ConstantDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ConstantDescriptorTest.php
@@ -15,6 +15,7 @@ use \Mockery as m;
 use phpDocumentor\Descriptor\Tag\AuthorDescriptor;
 use phpDocumentor\Descriptor\Tag\VarDescriptor;
 use phpDocumentor\Descriptor\Tag\VersionDescriptor;
+use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\String_;
 
@@ -81,12 +82,12 @@ class ConstantDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testSetAndGetTypes()
     {
-        $this->assertEquals(null, $this->fixture->getTypes());
+        $this->assertEquals(null, $this->fixture->getType());
         $expected = new Array_();
 
         $this->fixture->setTypes($expected);
 
-        $this->assertSame($expected, $this->fixture->getTypes());
+        $this->assertSame($expected, $this->fixture->getType());
     }
 
     /**
@@ -97,12 +98,12 @@ class ConstantDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $expected = new String_();
 
-        $varTag = m::mock('phpDocumentor\Descriptor\Tag\VarDescriptor');
-        $varTag->shouldReceive('getTypes')->andReturn($expected);
+        $varTag = new VarDescriptor('var');
+        $varTag->setTypes($expected);
 
         $this->fixture->getTags()->set('var', new Collection([$varTag]));
 
-        $this->assertSame($expected, $this->fixture->getTypes());
+        $this->assertEquals($expected, $this->fixture->getType());
     }
 
     /**
@@ -119,7 +120,7 @@ class ConstantDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
         // Attempt to get the types; which come from the superclass' constants
         $this->fixture->setParent($parentClass);
-        $types = $this->fixture->getTypes();
+        $types = $this->fixture->getType();
 
         $this->assertSame($expected, $types);
     }
@@ -340,16 +341,16 @@ class ConstantDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      * The created ParentClass can be used to test the inheritance of properties of a constant descriptor, such as
      * inheriting type information.
      *
-     * @param string[] $types
+     * @param Type $type
      * @param string $constantName
      *
      * @return m\MockInterface|ClassDescriptor
      */
-    protected function createParentClassWithSuperClassAndConstant($types, $constantName)
+    protected function createParentClassWithSuperClassAndConstant(Type $type, $constantName)
     {
         // construct the to-be-inherited constant and its @var tag
         $varTag = m::mock('phpDocumentor\Descriptor\Tag\VarDescriptor');
-        $varTag->shouldReceive('getTypes')->andReturn($types);
+        $varTag->shouldReceive('getType')->andReturn($type);
 
         $parentConstant = m::mock('\phpDocumentor\Descriptor\ConstantDescriptor');
         $parentConstant->shouldReceive('getVar')->andReturn(new Collection([$varTag]));

--- a/tests/unit/phpDocumentor/Descriptor/FunctionDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/FunctionDescriptorTest.php
@@ -64,6 +64,6 @@ class FunctionDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->fixture->setReturnType($stringType);
 
         $this->assertSame('return', $this->fixture->getResponse()->getName());
-        $this->assertSame($stringType, $this->fixture->getResponse()->getTypes());
+        $this->assertSame($stringType, $this->fixture->getResponse()->getType());
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/MethodDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/MethodDescriptorTest.php
@@ -124,7 +124,7 @@ class MethodDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $mock = new ReturnDescriptor('return');
         $mock->setTypes(new String_());
 
-        $this->assertNull($this->fixture->getResponse()->getTypes());
+        $this->assertNull($this->fixture->getResponse()->getType());
 
         $this->fixture->getTags()->set('return', new Collection([$mock]));
 
@@ -140,7 +140,7 @@ class MethodDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $returnType = new String_();
         $this->fixture->setReturnType($returnType);
 
-        $this->assertSame($returnType, $this->fixture->getResponse()->getTypes());
+        $this->assertSame($returnType, $this->fixture->getResponse()->getType());
     }
 
     /**

--- a/tests/unit/phpDocumentor/Descriptor/MethodDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/MethodDescriptorTest.php
@@ -122,7 +122,7 @@ class MethodDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     public function testRetrieveReturnTagForResponse()
     {
         $mock = new ReturnDescriptor('return');
-        $mock->setTypes(new String_());
+        $mock->setType(new String_());
 
         $this->assertNull($this->fixture->getResponse()->getType());
 

--- a/tests/unit/phpDocumentor/Descriptor/PropertyDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/PropertyDescriptorTest.php
@@ -83,7 +83,7 @@ class PropertyDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         // Arrange
         $typesCollection = new Array_();
         $varTagDescriptor = new VarDescriptor('var');
-        $varTagDescriptor->setTypes($typesCollection);
+        $varTagDescriptor->setType($typesCollection);
         $varCollection = new Collection([$varTagDescriptor]);
         $this->fixture->getTags()->clear();
         $this->fixture->getTags()->set('var', $varCollection);

--- a/tests/unit/phpDocumentor/Descriptor/PropertyDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/PropertyDescriptorTest.php
@@ -66,12 +66,12 @@ class PropertyDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testSetAndGetTypes()
     {
-        $this->assertEquals(new Collection(), $this->fixture->getTypes());
+        $this->assertEquals(null, $this->fixture->getType());
         $expected = new Array_();
 
         $this->fixture->setTypes($expected);
 
-        $this->assertSame($expected, $this->fixture->getTypes());
+        $this->assertSame($expected, $this->fixture->getType());
     }
 
     /**
@@ -89,7 +89,7 @@ class PropertyDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->fixture->getTags()->set('var', $varCollection);
 
         // Act
-        $result = $this->fixture->getTypes();
+        $result = $this->fixture->getType();
 
         // Assert
         $this->assertSame($typesCollection, $result);

--- a/tests/unit/phpDocumentor/Descriptor/Tag/ReturnDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/ReturnDescriptorTest.php
@@ -36,9 +36,9 @@ class ReturnDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     public function testSetAndGetTypes()
     {
         $expected = new Array_();
-        $this->assertEmpty($this->fixture->getTypes());
+        $this->assertNull($this->fixture->getType());
 
-        $this->fixture->setTypes($expected);
+        $this->fixture->setType($expected);
         $result = $this->fixture->getType();
 
         $this->assertEquals($expected, $result);

--- a/tests/unit/phpDocumentor/Descriptor/Tag/ReturnDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/ReturnDescriptorTest.php
@@ -39,7 +39,7 @@ class ReturnDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertEmpty($this->fixture->getTypes());
 
         $this->fixture->setTypes($expected);
-        $result = $this->fixture->getTypes();
+        $result = $this->fixture->getType();
 
         $this->assertEquals($expected, $result);
     }

--- a/tests/unit/phpDocumentor/Descriptor/TraitDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/TraitDescriptorTest.php
@@ -166,7 +166,7 @@ class TraitDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $mockTagPropertyDescriptor = m::mock('phpDocumentor\Descriptor\Tag\PropertyDescriptor');
         $mockTagPropertyDescriptor->shouldReceive('getVariableName')->andReturn('Sample');
         $mockTagPropertyDescriptor->shouldReceive('getDescription')->andReturn('Sample description');
-        $mockTagPropertyDescriptor->shouldReceive('getTypes')->andReturn(new Mixed_());
+        $mockTagPropertyDescriptor->shouldReceive('getType')->andReturn(new Mixed_());
 
         $propertyCollection = new Collection([$mockTagPropertyDescriptor]);
         $this->fixture->getTags()->set('property', $propertyCollection);
@@ -177,7 +177,7 @@ class TraitDescriptorTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame(1, $magicPropertiesCollection->count());
         $this->assertSame('Sample', $magicPropertiesCollection[0]->getName());
         $this->assertSame('Sample description', $magicPropertiesCollection[0]->getDescription());
-        $this->assertEquals(new Mixed_(), $magicPropertiesCollection[0]->getTypes());
+        $this->assertEquals(new Mixed_(), $magicPropertiesCollection[0]->getType());
         $this->assertSame($this->fixture, $magicPropertiesCollection[0]->getParent());
     }
 

--- a/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/ArgumentConverterTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/ArgumentConverterTest.php
@@ -11,28 +11,34 @@
 
 namespace phpDocumentor\Plugin\Core\Transformer\Writer\Xml;
 
-use Mockery as m;
 use phpDocumentor\Descriptor\ArgumentDescriptor;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for \phpDocumentor\Plugin\Core\Transformer\Writer\Xml\ArgumentConverter.
  *
- * @covers phpDocumentor\Plugin\Core\Transformer\Writer\Xml\ArgumentConverter
+ * @coversDefaultClass \phpDocumentor\Plugin\Core\Transformer\Writer\Xml\ArgumentConverter
+ * @covers ::<private>
  */
-class ArgumentConverterTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
+class ArgumentConverterTest extends TestCase
 {
     /**
      * Tests whether the XML Element representing an argument is properly created.
      *
-     * @covers phpDocumentor\Plugin\Core\Transformer\Writer\Xml\ArgumentConverter::convert
+     * @covers ::convert
      */
     public function testArgumentXmlElementIsCreated()
     {
         // Arrange
-        $tag = $this->createArgumentDescriptorMock();
-        $tag->shouldReceive('isByReference')->andReturn(false);
-        $tag->shouldReceive('getDefault')->andReturn(null);
-        $tag->shouldReceive('getTypes')->andReturn([]);
+        $tag = new ArgumentDescriptor();
+        $tag->setName('name');
+        $tag->setLine(100);
+        $tag->setByReference(false);
+        $tag->setDefault(null);
+        $tag->setType(null);
         $parent = $this->prepareParentXMLElement();
         $argumentConverter = new ArgumentConverter();
 
@@ -50,16 +56,19 @@ class ArgumentConverterTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     /**
      * Tests whether it is documented when an argument is by reference.
      *
-     * @covers phpDocumentor\Plugin\Core\Transformer\Writer\Xml\ArgumentConverter::convert
+     * @covers ::convert
      */
     public function testIfByReferenceIsDocumented()
     {
         // Arrange
         $argumentConverter = new ArgumentConverter();
         $parent = $this->prepareParentXMLElement();
-        $tag = $this->createArgumentDescriptorMock();
-        $tag->shouldReceive('isByReference')->andReturn(true);
-        $tag->shouldReceive('getTypes')->andReturn([]);
+        $tag = new ArgumentDescriptor();
+        $tag->setName('name');
+        $tag->setLine(100);
+        $tag->setByReference(true);
+        $tag->setDefault(null);
+        $tag->setType(null);
 
         // Act
         $convertedElement = $argumentConverter->convert($parent, $tag);
@@ -71,27 +80,31 @@ class ArgumentConverterTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     /**
      * Tests whether the type information for an argument is documented.
      *
-     * @covers phpDocumentor\Plugin\Core\Transformer\Writer\Xml\ArgumentConverter::convert
+     * @covers ::convert
      */
     public function testIfTypeInformationIsDocumented()
     {
         // Arrange
         $argumentConverter = new ArgumentConverter();
         $parent = $this->prepareParentXMLElement();
-        $tag = $this->createArgumentDescriptorMock();
-        $tag->shouldReceive('getTypes')->andReturn(['string', 'integer']);
+        $tag = new ArgumentDescriptor();
+        $tag->setName('name');
+        $tag->setLine(100);
+        $tag->setByReference(true);
+        $tag->setDefault(null);
+        $tag->setType(new Compound([new String_(), new Integer()]));
 
         // Act
         $convertedElement = $argumentConverter->convert($parent, $tag);
 
         // Assert
-        $this->assertSame('string|integer', $convertedElement->getElementsByTagName('type')->item(0)->nodeValue);
+        $this->assertSame('string|int', $convertedElement->getElementsByTagName('type')->item(0)->nodeValue);
     }
 
     /**
      * Tests whether the default for an argument is documented.
      *
-     * @covers phpDocumentor\Plugin\Core\Transformer\Writer\Xml\ArgumentConverter::convert
+     * @covers ::convert
      */
     public function testIfDefaultValueIsDocumented()
     {
@@ -99,9 +112,13 @@ class ArgumentConverterTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $default = 'This is a default';
         $argumentConverter = new ArgumentConverter();
         $parent = $this->prepareParentXMLElement();
-        $tag = $this->createArgumentDescriptorMock();
-        $tag->shouldReceive('getDefault')->andReturn($default);
-        $tag->shouldReceive('getTypes')->andReturn([]);
+        $tag = new ArgumentDescriptor();
+        $tag->setName('name');
+        $tag->setLine(100);
+        $tag->setByReference(true);
+        $tag->setDefault($default);
+        $tag->setType(new Compound([new String_(), new Integer()]));
+
 
         // Act
         $convertedElement = $argumentConverter->convert($parent, $tag);
@@ -122,20 +139,5 @@ class ArgumentConverterTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $document->appendChild($parent);
 
         return $parent;
-    }
-
-    /**
-     * Creates a mock for the ArgumentDescriptor class.
-     *
-     * @return m\MockInterface|ArgumentDescriptor
-     */
-    protected function createArgumentDescriptorMock()
-    {
-        $tag = m::mock('phpDocumentor\\Descriptor\\ArgumentDescriptor');
-        $tag->shouldReceive('getLine')->andReturn(100);
-        $tag->shouldReceive('getName')->andReturn('name');
-        $tag->shouldIgnoreMissing();
-
-        return $tag;
     }
 }

--- a/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/TagConverterTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/TagConverterTest.php
@@ -68,7 +68,7 @@ class TagConverterTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $tagConverter = new TagConverter();
         $parent = $this->prepareDocBlockXMLElement();
         $tag = $this->createTagDescriptorMock('name', 'description', 'Tag\VarDescriptor');
-        $tag->shouldReceive('getTypes')->andReturn(
+        $tag->shouldReceive('getType')->andReturn(
             new Compound([new String_(), new Integer(), new Object_(new Fqsen('\DateTime'))])
         );
 
@@ -96,7 +96,7 @@ class TagConverterTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $tagConverter = new TagConverter();
         $parent = $this->prepareDocBlockXMLElement();
         $tag = $this->createTagDescriptorMock('name', 'description', 'Tag\VarDescriptor');
-        $tag->shouldReceive('getTypes')->andReturn(new String_());
+        $tag->shouldReceive('getType')->andReturn(new String_());
 
         // Act
         $convertedElement = $tagConverter->convert($parent, $tag);
@@ -119,7 +119,7 @@ class TagConverterTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $tagConverter = new TagConverter();
         $parent = $this->prepareDocBlockXMLElement();
         $tag = $this->createTagDescriptorMock('name', 'description', 'Tag\VarDescriptor');
-        $tag->shouldReceive('getTypes')->andReturn(null);
+        $tag->shouldReceive('getType')->andReturn(null);
         $tag->shouldReceive('getVariableName')->andReturn('varName');
 
         // Act


### PR DESCRIPTION
In the new phpdocumentor we changed the usage of type arrays to new
reflection oriented types. This caused a number of bc issues in templates.
To fix this I switched back to use the array notation.

The setTypes and getTypes methods of descriptors are now deprecated. And
should be replaced by the non pural variants.

refs #2020
fixes #1974