### PR TITLE
fix schema path in config/services.yaml

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -125,7 +125,7 @@ services:
     phpDocumentor\Configuration\Factory\Version2:
         tags: [phpdoc.config_strategy]
     phpDocumentor\Configuration\Factory\Version3:
-        arguments: ['data/xsd/phpdoc.xsd']
+        arguments: ["@=service('kernel').getProjectDir() ~ '/data/xsd/phpdoc.xsd'"]
         tags: [phpdoc.config_strategy]
     phpDocumentor\Configuration\ConfigurationFactory:
         arguments:


### PR DESCRIPTION
Without this fix phpDocumentor is looking for ``data/xsd/phpdoc.xsd`` in the working directory. The file, in fact, is located in phpdoc's root directory.