### PR TITLE
Fix loading V3 config from default locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,20 @@ var/*
 *.phar
 screenshots
 
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+*.swp
+*.bkp
+*.bak
+*~
+.~lock.*
+
 # By default the phpunit.xml.dist is provided; you can override this using a local config file
 phpunit.xml
 

--- a/src/phpDocumentor/Configuration/ConfigurationFactory.php
+++ b/src/phpDocumentor/Configuration/ConfigurationFactory.php
@@ -17,6 +17,7 @@ namespace phpDocumentor\Configuration;
 
 use phpDocumentor\Configuration\Factory\Strategy;
 use phpDocumentor\Configuration\Factory\Version3;
+use phpDocumentor\Configuration\Exception\InvalidConfigPathException;
 use phpDocumentor\Uri;
 use RuntimeException;
 
@@ -77,7 +78,7 @@ final class ConfigurationFactory
         foreach ($this->defaultFiles as $file) {
             try {
                 return $this->fromUri(new Uri($file));
-            } catch (\InvalidArgumentException $e) {
+            } catch (InvalidConfigPathException $e) {
                 continue;
             }
         }
@@ -92,13 +93,14 @@ final class ConfigurationFactory
      *
      * @return Configuration
      * @throws RuntimeException if no matching strategy can be found.
+     * @throws InvalidConfigPathException if $uri points to an inexistent file
      */
     public function fromUri(Uri $uri): Configuration
     {
         $filename = (string) $uri;
 
         if (!file_exists($filename)) {
-            throw new \InvalidArgumentException(sprintf('File %s could not be found', $filename));
+          throw new InvalidConfigPathException(sprintf('File %s could not be found', $filename));
         }
 
         $xml = new \SimpleXMLElement($filename, 0, true);

--- a/src/phpDocumentor/Configuration/Exception/InvalidConfigPathException.php
+++ b/src/phpDocumentor/Configuration/Exception/InvalidConfigPathException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author    Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright 2010-2018 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Configuration\Exception;
+
+class InvalidConfigPathException extends \InvalidArgumentException
+{
+
+}


### PR DESCRIPTION
A V3 config file containing errors is currently silently ignored, and either a default configuration is used or a next (possibly V2) file if exists. This seems to be quite counter-intuitive. An existing config file should rather be reported to contain errors, if it is the case. This PR provides a fix for this.